### PR TITLE
Fixed NUnit installation for the Boogie build process.

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -332,7 +332,7 @@ then
   cd ${BOOGIE_DIR}/Source
   mozroots --import --sync
   ${WGET} https://nuget.org/nuget.exe
-  mono ./nuget.exe restore Boogie.sln
+  sudo mono ./nuget.exe restore Boogie.sln
   xbuild Boogie.sln /p:Configuration=Release
   ln -s ${Z3_DIR}/bin/z3 ${BOOGIE_DIR}/Binaries/z3.exe
 


### PR DESCRIPTION
The Boogie build process needs sudo privilege to install NUnit. 