### PR TITLE
Fix Boogie and Corral wrapper scripts so that each argument passed to

### DIFF
--- a/bin/boogie
+++ b/bin/boogie
@@ -1,3 +1,3 @@
 #!/bin/bash
-$BOOGIE $@
+$BOOGIE "$@"
 

--- a/bin/corral
+++ b/bin/corral
@@ -1,3 +1,3 @@
 #!/bin/bash
-$CORRAL $@
+$CORRAL "$@"
 


### PR DESCRIPTION
the script is quoted. Previously if parameters with spaces in were passed to the script
then those parameters would be split into separate parameters.

E.g.

./boogie "my silly file name with spaces in it.bpl"

will expand to

/path/to/Boogie.exe "my" "silly" "file" "name" "with" "spaces" "in"
"it.bpl"

when invoked which would most likely fail.