### PR TITLE
Modified the build and test scripts so that test failures are reported.

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -386,6 +386,9 @@ then
 
   cd ${SMACK_DIR}/test
   ./regtest.py
+  res=$?
 
   puts "Regression tests complete"
 fi
+
+exit $res

--- a/test/regtest.py
+++ b/test/regtest.py
@@ -239,5 +239,10 @@ def main():
     logging.info(' TIMEOUT count: %d' % timeouts)
     logging.info(' UNKNOWN count: %d' % unknowns)
 
+    # if there are any failed tests or tests that timed out, set the system
+    # exit code to a failure status
+    if timeouts > 0 or failed > 0:
+        sys.exit(1)
+
 if __name__=="__main__":
     main()

--- a/test/regtest.py
+++ b/test/regtest.py
@@ -242,7 +242,7 @@ def main():
     # if there are any failed tests or tests that timed out, set the system
     # exit code to a failure status
     if timeouts > 0 or failed > 0:
-        sys.exit(1)
+       sys.exit(1)
 
 if __name__=="__main__":
     main()


### PR DESCRIPTION
Before these changes Jenkins reported builds as successful even if there were tests
that timed out/failed. This fixes that issue by setting the shell return status
based on the results of the regressions tests. Jenkins will now report a build as
failed if the shell return status is anything other than 0.