### PR TITLE
Added a test showing string translation issue. Also fixed path in Makefile

### DIFF
--- a/examples/simple-project/Makefile
+++ b/examples/simple-project/Makefile
@@ -1,5 +1,5 @@
 # Set this variable to point to folder share of your SMACK installation
-INSTALL_SHARE = ../../../install/share
+INSTALL_SHARE = ../../share
 
 CC = clang
 LD = llvm-link

--- a/examples/simple-project/incr.c
+++ b/examples/simple-project/incr.c
@@ -9,3 +9,7 @@ int incr(int x) {
   return x + y;
 }
 
+char* retStr() {
+  char* s1 = "1string";
+  return s1;
+}

--- a/examples/simple-project/simple.c
+++ b/examples/simple-project/simple.c
@@ -10,10 +10,17 @@ void test(int a) {
   assert(a > b);
 }
 
+void test2() {
+  char* s1 = "1string";
+  assert(s1!=retStr());
+
+}
+
 int main(void) {
   int a = __VERIFIER_nondet();
   assume(a < 10000); // prevents overflow when bit-precise
   test(a);
+  test2();
   return 0;
 }
 


### PR DESCRIPTION
Added small test showing that current handling of strings causes problems in the translated bpl.

The assertion  assert(s1!=retStr()); can be proved although the two string literals are the same.

Using a hash of the string literal when generating the boogie variable would address the issue I think.