### PR TITLE
Add Symbooglix as a backend verifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ INSTALL(TARGETS llvm2bpl
 INSTALL(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/bin/boogie
   ${CMAKE_CURRENT_SOURCE_DIR}/bin/corral
+  ${CMAKE_CURRENT_SOURCE_DIR}/bin/symbooglix
   ${CMAKE_CURRENT_SOURCE_DIR}/bin/lockpwn
   ${CMAKE_CURRENT_SOURCE_DIR}/bin/smack
   ${CMAKE_CURRENT_SOURCE_DIR}/bin/smack-doctor

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -407,6 +407,7 @@ then
   puts "Configuring shell environment"
   echo export BOOGIE=\"mono ${BOOGIE_DIR}/Binaries/Boogie.exe\" >> ${SMACKENV}
   echo export CORRAL=\"mono ${CORRAL_DIR}/bin/Release/corral.exe\" >> ${SMACKENV}
+  echo export SYMBOOGLIX=\"mono ${SYMBOOGLIX_DIR}/src/SymbooglixDriver/bin/Release/sbx.exe\" >> ${SMACKENV}
   echo export LOCKPWN=\"mono ${LOCKPWN_DIR}/Binaries/lockpwn.exe\" >> ${SMACKENV}
   source ${SMACKENV}
   puts "The required environment variables have been set in ${SMACKENV}"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -370,8 +370,10 @@ then
   cd ${ROOT}
   git clone https://github.com/symbooglix/symbooglix.git ${SYMBOOGLIX_DIR} 
   cd ${SYMBOOGLIX_DIR}/src
+  git submodule init
+  git submodule update
   ${WGET} https://dist.nuget.org/win-x86-commandline/v2.8.6/nuget.exe
-  mono nuget.exe restore symbooglix.sln
+  mono ./nuget.exe restore Symbooglix.sln
   xbuild /p:Configuration=Release
   ln -s ${Z3_DIR}/bin/z3 ${SYMBOOGLIX_DIR}/src/SymbooglixDriver/bin/Release/z3.exe
   ln -s ${Z3_DIR}/bin/z3 ${SYMBOOGLIX_DIR}/src/Symbooglix/bin/Release/z3.exe

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -24,6 +24,7 @@ INSTALL_DEPENDENCIES=1
 BUILD_Z3=1
 BUILD_BOOGIE=1
 BUILD_CORRAL=1
+BUILD_SYMBOOGLIX=1 
 BUILD_LOCKPWN=0
 BUILD_SMACK=1
 TEST_SMACK=1
@@ -36,6 +37,7 @@ ROOT="$( cd "${SMACK_DIR}" && cd .. && pwd )"
 Z3_DIR="${ROOT}/z3"
 BOOGIE_DIR="${ROOT}/boogie"
 CORRAL_DIR="${ROOT}/corral"
+SYMBOOGLIX_DIR="${ROOT}/symbooglix"
 LOCKPWN_DIR="${ROOT}/lockpwn"
 MONO_DIR="${ROOT}/mono"
 LLVM_DIR="${ROOT}/llvm"
@@ -359,6 +361,22 @@ then
   ln -s ${Z3_DIR}/bin/z3 ${CORRAL_DIR}/bin/Release/z3.exe
 
   puts "Built Corral"
+fi
+
+if [ ${BUILD_SYMBOOGLIX} -eq 1 ]
+then
+  puts "Building Symbooglix"
+
+  cd ${ROOT}
+  git clone https://github.com/symbooglix/symbooglix.git ${SYMBOOGLIX_DIR} 
+  cd ${SYMBOOGLIX_DIR}/src
+  ${WGET} https://dist.nuget.org/win-x86-commandline/v2.8.6/nuget.exe
+  mono nuget.exe restore symbooglix.sln
+  xbuild /p:Configuration=Release
+  ln -s ${Z3_DIR}/bin/z3 ${SYMBOOGLIX_DIR}/src/SymbooglixDriver/bin/Release/z3.exe
+  ln -s ${Z3_DIR}/bin/z3 ${SYMBOOGLIX_DIR}/src/Symbooglix/bin/Release/z3.exe
+
+  puts "Built Symbooglix"
 fi
 
 if [ ${BUILD_LOCKPWN} -eq 1 ]

--- a/bin/symbooglix
+++ b/bin/symbooglix
@@ -1,0 +1,2 @@
+#!/bin/bash
+$SYMBOOGLIX "$@"

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -235,7 +235,7 @@ def try_command(cmd, cwd=None, console=False, timeout=None):
     proc = None
     if timeout and timed_out[0]:
       return output + ("\n%s timed out." % cmd[0])
-    elif rc:
+    elif rc and args.verifier != "symbooglix":
       raise RuntimeError("%s returned non-zero." % cmd[0])
     else:
       return output
@@ -385,11 +385,11 @@ def annotate_bpl(args):
     f.write(bpl)
 
 def verification_result(verifier_output):
-  if re.search(r'[1-9]\d* time out|Z3 ran out of resources|timed out', verifier_output):
+  if re.search(r'[1-9]\d* time out|Z3 ran out of resources|timed out|ERRORS_TIMEOUT', verifier_output):
     return 'timeout'
-  elif re.search(r'[1-9]\d* verified, 0 errors?|no bugs', verifier_output):
+  elif re.search(r'[1-9]\d* verified, 0 errors?|no bugs|NO_ERRORS_NO_TIMEOUT$', verifier_output):
     return 'verified'
-  elif re.search(r'\d* verified, [1-9]\d* errors?|can fail', verifier_output):
+  elif re.search(r'\d* verified, [1-9]\d* errors?|can fail|ERRORS_NO_TIMEOUT$', verifier_output):
     return 'error'
   else:
     return 'unknown'

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -433,7 +433,7 @@ def verify_bpl(args):
     command += ["/tryCTrace", "/noTraceOnDisk", "/useDuality", "/oldStratifiedInlining"]
     command += ["/recursionBound:1073741824", "/k:1"]
 
-  if args.bit_precise:
+  if args.bit_precise and args.verifier != "symbooglix":
     x = "bopt:" if args.verifier != 'boogie' else ""
     command += ["/%sproverOpt:OPTIMIZE_FOR_BV=true" % x]
     command += ["/%sz3opt:smt.relevancy=0" % x]

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -138,7 +138,7 @@ def arguments():
   verifier_group = parser.add_argument_group('verifier options')
 
   verifier_group.add_argument('--verifier',
-    choices=['boogie', 'corral', 'duality', 'svcomp'],
+    choices=['boogie', 'corral', 'duality', 'svcomp', 'symbooglix'],
     help='back-end verification engine')
 
   verifier_group.add_argument('--unroll', metavar='N', default='1',
@@ -419,6 +419,13 @@ def verify_bpl(args):
     command += ["/cex:%s" % args.max_violations]
     command += ["/maxStaticLoopBound:%d" % args.loop_limit]
     command += ["/recursionBound:%d" % args.unroll]
+
+  elif args.verifier == 'symbooglix':
+    command = ['symbooglix']
+    command += [args.bpl_file]
+    command += ["--file-logging", "0"]
+    command += ["--entry-points", ",".join(args.entry_points)]
+    command += ["--max-depth", str(args.unroll)]
 
   else:
     # Duality!

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -423,9 +423,10 @@ def verify_bpl(args):
   elif args.verifier == 'symbooglix':
     command = ['symbooglix']
     command += [args.bpl_file]
-    command += ["--file-logging", "0"]
-    command += ["--entry-points", ",".join(args.entry_points)]
-    command += ["--max-depth", str(args.unroll)]
+    command += ["--file-logging=0"]
+    command += ["--entry-points=%s" % ",".join(args.entry_points)]
+    command += ["--timeout=%d" % args.time_limit]
+    command += ["--max-depth=%d" % args.unroll]
 
   else:
     # Duality!

--- a/test/config.yml
+++ b/test/config.yml
@@ -1,4 +1,4 @@
-verifiers: [boogie, corral]
+verifiers: [boogie, corral, symbooglix]
 memory: [no-reuse-impls, no-reuse, reuse]
 time-limit: 120
 flags: [ --unroll=2 ]


### PR DESCRIPTION
**Symbooglix** is a symbolic execution engine for Boogie programs. So we would like to add it to our backend verifier arsenal. This pull request implements support to Symbooglix,
- Modify build script to fetch Symbooglix repo, build it, and update the environment.
- Create a binary called `symbooglix` which is similar to `boogie` and `corral`.
- Modify `top.py` to invoke Symbooglix.

The following issues are worth discussion,
- Symbooglix uses return code to indicate verification result and exceptions/errors occurred as opposed to Boogie/Corral. Details of exit codes can be found at https://github.com/symbooglix/symbooglix/blob/be450d80e744aae664e581ded9d3136e0a36b828/src/SymbooglixDriver/Driver.cs#L237. I didn't change `try_command` to process return code. Instead I did it in `verification_result` which searches for return codes while does not raise exceptions when something goes wrong for Symbooglix.
- The behavior of `--max-depth` is different from `/loopUnroll` of Boogie and `/recursionBound` of Corral. Note that Symbooglix has a special return code called `NO_ERRORS_NO_TIMEOUT_BUT_HIT_BOUND` which indicates a "unrolling" bound is reached. For some examples (e.g. `globals_fail.c`), unrolling bound `2` suffices to expose the bug for Boogie or Corral while Symbooglix returns the code mentioned above.
- The verification result when Symbooglix returns `NO_ERRORS_NO_TIMEOUT_BUT_HIT_BOUND` and `NO_ERRORS_NO_TIMEOUT_BUT_FOUND_SPECULATIVE_PATHS` is `unknown` even though the program being verified may not contain any bugs.
