### PR TITLE
Removed long double function signatures

### DIFF
--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -198,7 +198,7 @@ int fpclassify(double x);
 int __finite(double x);
 
 //long doubles
-int __isnormall(long double x);
+/*int __isnormall(long double x);
 int __isSubnormall(long double x);
 int __iszerol(long double x);
 int __isinfl(long double x);
@@ -209,7 +209,7 @@ int __signbitl(long double x);
 int signbitl(long double x);
 int __fpclassifyl(long double x);
 int fpclassifyl(long double x);
-int __finitel(long double x);
+int __finitel(long double x);*/
 #endif
 
 #undef S1

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -635,7 +635,7 @@ int __finite(double x) {
   return !__isinf(x) && !__isnan(x);
 }
 
-int __isnormall(long double x) {
+/*int __isnormall(long double x) {
   int ret = __VERIFIER_nondet_int();
   __SMACK_code("@ := if $isnormal.bvlongdouble(@) then 1bv32 else 0bv32;", ret, x);
   return ret;
@@ -705,7 +705,7 @@ int fpclassifyl(long double x) {
 
 int __finitel(long double x) {
   return !__isinfl(x) && !__isnanl(x);
-}
+}*/
 #endif
 
 void __SMACK_dummy(int v) {


### PR DESCRIPTION
They cause some tests to fail and are currently unnecessary.