### PR TITLE
Error replay

### DIFF
--- a/include/smack/SmackInstGenerator.h
+++ b/include/smack/SmackInstGenerator.h
@@ -37,6 +37,8 @@ private:
   void nameInstruction(llvm::Instruction& i);
   void annotate(llvm::Instruction& i, Block* b);
 
+  const Stmt* recordProcedureCall(llvm::Value* V, std::list<const Attr*> attrs);
+
 public:
   void emit(const Stmt* s) {
     // stringstream str;

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -619,9 +619,8 @@ void SmackInstGenerator::visitCallInst(llvm::CallInst& ci) {
       emit(Stmt::assume(Expr::fn(Naming::EXTERNAL_ADDR,rep.expr(&ci))));
   }
 
-  if (f->isDeclaration()
-      && !f->getReturnType()->isVoidTy()
-      && naming.get(*f).find("CONTRACT") == std::string::npos) {
+  if ((naming.get(*f).find("__SMACK") == 0 || naming.get(*f).find("__VERIFIER") == 0)
+      && !f->getReturnType()->isVoidTy()) {
     emit(recordProcedureCall(&ci, {Attr::attr("cexpr", "smack:ext:" + naming.get(*f))}));
   }
 }

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -103,7 +103,7 @@ void SmackInstGenerator::visitBasicBlock(llvm::BasicBlock& bb) {
   auto name = naming.get(*F);
   if (SmackOptions::isEntryPoint(naming.get(*F)) && &bb == &F->getEntryBlock()) {
     for (auto& I : bb.getInstList()) {
-      if (!llvm::isa<llvm::DbgValueInst>(I)) {
+      if (!llvm::isa<llvm::DbgInfoIntrinsic>(I) && !llvm::isa<llvm::AllocaInst>(I)) {
         annotate(I, currBlock);
         break;
       }

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -108,6 +108,7 @@ void SmackInstGenerator::visitBasicBlock(llvm::BasicBlock& bb) {
         break;
       }
     }
+    emit(recordProcedureCall(F, {Attr::attr("cexpr", "smack:entry:" + naming.get(*F))}));
     for (auto& A : F->getArgumentList()) {
       emit(recordProcedureCall(&A, {Attr::attr("cexpr", "smack:arg:" + naming.get(*F) + ":" + naming.get(A))}));
     }

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -620,7 +620,9 @@ void SmackInstGenerator::visitCallInst(llvm::CallInst& ci) {
       emit(Stmt::assume(Expr::fn(Naming::EXTERNAL_ADDR,rep.expr(&ci))));
   }
 
-  if (f->isDeclaration() && !f->getReturnType()->isVoidTy()) {
+  if (f->isDeclaration()
+      && !f->getReturnType()->isVoidTy()
+      && naming.get(*f).find("CONTRACT") == std::string::npos) {
     emit(recordProcedureCall(&ci, {Attr::attr("cexpr", "smack:ext:" + naming.get(*f))}));
   }
 }

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -103,7 +103,9 @@ void SmackInstGenerator::visitBasicBlock(llvm::BasicBlock& bb) {
   auto name = naming.get(*F);
   if (SmackOptions::isEntryPoint(naming.get(*F)) && &bb == &F->getEntryBlock()) {
     for (auto& I : bb.getInstList()) {
-      if (!llvm::isa<llvm::DbgInfoIntrinsic>(I) && !llvm::isa<llvm::AllocaInst>(I)) {
+      if (llvm::isa<llvm::DbgInfoIntrinsic>(I))
+        continue;
+      if (I.getDebugLoc()) {
         annotate(I, currBlock);
         break;
       }

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -100,7 +100,6 @@ void SmackInstGenerator::visitBasicBlock(llvm::BasicBlock& bb) {
   currBlock = getBlock(&bb);
 
   auto* F = bb.getParent();
-  auto name = naming.get(*F);
   if (SmackOptions::isEntryPoint(naming.get(*F)) && &bb == &F->getEntryBlock()) {
     for (auto& I : bb.getInstList()) {
       if (llvm::isa<llvm::DbgInfoIntrinsic>(I))

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -1,2 +1,86 @@
-def replay_error_trace(verifier_output):
-    print "TODO: replay the erorr trace"
+import os
+import subprocess
+import sys
+from utils import temporary_file, try_command
+
+STUBBABLE_FUNCTIONS = [
+  "__VERIFIER_nondet"
+]
+
+def replay_error_trace(verifier_output, args):
+  read, write = os.pipe()
+  os.write(write, verifier_output)
+  os.close(write)
+  with open(args.replay_harness, 'w') as f:
+    f.write(stub_module(aggregate_values(collect_returns(read))))
+
+  stubs_bc = temporary_file('stubs', '.bc', args)
+  try_command(['clang', '-c', '-emit-llvm', '-o', stubs_bc, args.replay_harness])
+  try_command(['clang', '-o', args.replay_exe_file, args.bc_file, stubs_bc])
+  print "Generated replay harness:", args.replay_harness
+  print "Generated replay executable:", args.replay_exe_file
+
+  if try_command(["./" + args.replay_exe_file]):
+    print "Error-trace replay successful."
+
+  else:
+    print "Error-trace replay failed."
+
+
+def collect_returns(stream):
+  return reduce(
+  (lambda s, c: subprocess.Popen(c, stdin=s, stdout=subprocess.PIPE).stdout), [
+    ["grep", "-A", "1", "-e", "RETURN from \(%s\)" % "\|".join(STUBBABLE_FUNCTIONS)],
+    ["sed", "s/.*  (\(.*\))/\\1/"],
+    ["cut", "-d", " ", "-f3"],
+    ["grep", "-v", "-e", "--"],
+    ["paste", "-d,", "-", "-"]
+  ], stream)
+
+
+def aggregate_values(stream):
+  dict = {}
+  for line in stream:
+    fn, val = line.strip().split(",")
+    if not fn in dict:
+        dict[fn] = []
+    dict[fn].append(val)
+  return dict
+
+
+def stub_module(dict):
+  code = []
+  code.append("""//
+// This file was automatically generated from a Boogie error trace.
+// It contains stubs for unspecified functions that were called in that trace.
+// These stubs will return the same values they did in the error trace.
+// This file can be linked with the source program to reproduce the error.
+//
+#include <stdlib.h>
+#include <stdio.h>
+
+void __VERIFIER_assert(int b) {
+  if (!b)
+    printf("error reached!\\n");
+    exit(0);
+}
+
+void __VERIFIER_assume(int b) {
+  if (!b) {
+    printf("assumption does not hold.\\n");
+    exit(-1);
+  }
+}
+""")
+
+  for fn, vals in dict.items():
+    code.append("""// stub for function: %(fn)s
+int %(fn)s$table[] = {%(vals)s};
+int %(fn)s$idx = 0;
+
+int %(fn)s() {
+  return %(fn)s$table[%(fn)s$idx++];
+}
+""" % {'fn': fn, 'vals': ", ".join(vals)})
+
+  return "\n".join(code)

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -10,7 +10,11 @@ STUBBABLE_FUNCTIONS = [
 def replay_error_trace(verifier_output, args):
 
   if args.entry_points != ['main']:
-    print "Replay for entrypoints other than `main` current unsupported; skipping replay"
+    print "Replay for entrypoints other than 'main' currently unsupported; skipping replay"
+    return
+
+  if args.verifier != 'corral':
+    print "Replay for verifiers other than 'corral' currently unsupported; skipping replay"
     return
 
   read, write = os.pipe()

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -8,6 +8,11 @@ STUBBABLE_FUNCTIONS = [
 ]
 
 def replay_error_trace(verifier_output, args):
+
+  if args.entry_points != ['main']:
+    print "Replay for entrypoints other than `main` current unsupported; skipping replay"
+    return
+
   read, write = os.pipe()
   os.write(write, verifier_output)
   os.close(write)

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -94,6 +94,7 @@ void __VERIFIER_assume(int b) {
 
   for fn, vals in dict.items():
     if not fn in missing_definitions:
+      print "warning: using native implementation of function %s" % fn
       continue
 
     code.append("""// stub for function: %(fn)s

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -66,10 +66,14 @@ def aggregate_values(stream):
     key, val = line.strip().split(",")
     key = key.replace('SMACK_nondet', 'VERIFIER_nondet')
 
+    if 'entry:' in key:
+      _, fn = key.split(':')
+      arguments[fn] = []
+
     if 'arg:' in key:
       _, fn, arg = key.split(':')
       if not fn in arguments:
-        arguments[fn] = []
+        raise Exception("expected entry point key smack:entry:%s" % fn)
       arguments[fn].append(val)
 
     elif 'ext:' in key:

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -19,6 +19,9 @@ def replay_error_trace(verifier_output, args):
 
   missing_definitions = detect_missing_definitions(args.bc_file)
 
+  if '__SMACK_code' in missing_definitions:
+    print "warning: inline Boogie code found; replay may fail"
+
   read, write = os.pipe()
   os.write(write, verifier_output)
   os.close(write)

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -4,11 +4,13 @@ import subprocess
 import sys
 from utils import temporary_file, try_command
 
+SPECIAL_NAMES = ['__VERIFIER_assert', '__VERIFIER_assume', 'main']
+
 def replay_error_trace(verifier_output, args):
 
-  if args.entry_points != ['main']:
-    print "Replay for entrypoints other than 'main' currently unsupported; skipping replay"
-    return
+  # if args.entry_points != ['main']:
+  #   print "Replay for entrypoints other than 'main' currently unsupported; skipping replay"
+  #   return
 
   if args.verifier != 'corral':
     print "Replay for verifiers other than 'corral' currently unsupported; skipping replay"
@@ -29,7 +31,7 @@ def replay_error_trace(verifier_output, args):
     f.write(stub_module(aggregate_values(collect_returns(read)), missing_definitions))
 
   try_command(['clang', '-c', '-emit-llvm', '-o', stubs_bc, args.replay_harness])
-  try_command(['clang', '-o', args.replay_exe_file, args.bc_file, stubs_bc])
+  try_command(['clang', '-Wl,-e,_smack_replay_main', '-o', args.replay_exe_file, args.bc_file, stubs_bc])
 
   print "Generated replay harness:", args.replay_harness
   print "Generated replay executable:", args.replay_exe_file
@@ -44,8 +46,8 @@ def replay_error_trace(verifier_output, args):
 def collect_returns(stream):
   return reduce(
   (lambda s, c: subprocess.Popen(c, stdin=s, stdout=subprocess.PIPE).stdout), [
-    ["grep", "ext:"],
-    ["sed", "s/.*ext:\(.*\) = \(.*\))/\\1,\\2/"]
+    ["grep", "(smack:"],
+    ["sed", "s/.*(smack:\(.*\) = \(.*\))/\\1,\\2/"]
   ], stream)
 
 def detect_missing_definitions(failed_clang_output):
@@ -68,6 +70,20 @@ def aggregate_values(stream):
 
 
 def stub_module(dict, missing_definitions):
+  return_values = {}
+  arguments = {}
+  for key, vals in dict.items():
+    if 'ext:' in key:
+      _, fn = key.split(':')
+      return_values[fn] = vals
+    elif 'arg:' in key:
+      _, fn, arg = key.split(':')
+      if not fn in arguments:
+        arguments[fn] = {}
+      arguments[fn][arg] = vals[0]
+    else:
+      print "warning: unexpected key %s" % key
+
   code = []
   code.append("""//
 // This file was automatically generated from a Boogie error trace.
@@ -92,18 +108,35 @@ void __VERIFIER_assume(int b) {
 }
 """)
 
-  for fn, vals in dict.items():
-    if not fn in missing_definitions:
-      print "warning: using native implementation of function %s" % fn
-      continue
-
-    code.append("""// stub for function: %(fn)s
+  for fn in set(missing_definitions) - set(SPECIAL_NAMES):
+    if fn in return_values:
+      code.append("""// stub for function: %(fn)s
 int %(fn)s$table[] = {%(vals)s};
 int %(fn)s$idx = 0;
 
 int %(fn)s() {
   return %(fn)s$table[%(fn)s$idx++];
 }
-""" % {'fn': fn, 'vals': ", ".join(vals)})
+""" % {'fn': fn, 'vals': ", ".join(return_values[fn])})
+
+    else:
+      print "warning: cannot generate stub for %s" % fn
+
+  for f in set(return_values) - set(missing_definitions):
+    print "warning: using native implementation of function %s" % fn
+
+
+  if len(arguments) > 1:
+    print "warning: multiple entrypoint argument annotations found"
+  elif len(arguments) < 1:
+    print "warning: no entrypoint argument annotations found"
+
+  for fn, args in arguments.items():
+    code.append("""// entry point wrapper
+int smack_replay_main() {
+  %(fn)s(%(vals)s);
+  return 0;
+}
+""" % {'fn': fn, 'vals': ", ".join(args.values())})
 
   return "\n".join(code)

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -20,7 +20,7 @@ def replay_error_trace(verifier_output, args):
   try:
     try_command(['clang', '-o', args.replay_exe_file, args.bc_file])
   except Exception as err:
-    missing_definitions = detect_missing_definitions(err[1])
+    missing_definitions = detect_missing_definitions(err.message)
 
   read, write = os.pipe()
   os.write(write, verifier_output)

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -15,6 +15,8 @@ def replay_error_trace(verifier_output, args):
     print "Replay for verifiers other than 'corral' currently unsupported; skipping replay"
     return
 
+  print "Attempting to replay error trace."
+
   missing_definitions = detect_missing_definitions(args.bc_file)
 
   read, write = os.pipe()

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -52,7 +52,7 @@ def detect_missing_definitions(bc_file):
     try_command(['clang', bc_file])
   except Exception as err:
     for line in err.message.split("\n"):
-      m = re.search(r'\"_(.*)\", referenced from:', line)
+      m = re.search(r'\"_(.*)\", referenced from:', line) or re.search(r'undefined reference to `(.*)\'', line)
       if m:
         missing.append(m.group(1))
   return missing

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -37,7 +37,7 @@ def replay_error_trace(verifier_output, args):
   print "Generated replay executable:", args.replay_exe_file
 
   try:
-    if try_command(["./" + args.replay_exe_file]):
+    if 'error reached!' in try_command(["./" + args.replay_exe_file]):
       print "Error-trace replay successful."
       return True
 
@@ -112,9 +112,10 @@ def harness(arguments, return_values, missing_definitions):
 #include <stdio.h>
 
 void __VERIFIER_assert(int b) {
-  if (!b)
+  if (!b) {
     printf("error reached!\\n");
     exit(0);
+  }
 }
 
 void __VERIFIER_assume(int b) {

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -33,11 +33,18 @@ def replay_error_trace(verifier_output, args):
   print "Generated replay harness:", args.replay_harness
   print "Generated replay executable:", args.replay_exe_file
 
-  if try_command(["./" + args.replay_exe_file]):
-    print "Error-trace replay successful."
+  try:
+    if try_command(["./" + args.replay_exe_file]):
+      print "Error-trace replay successful."
+      return True
 
-  else:
-    print "Error-trace replay failed."
+    else:
+      print "Error-trace replay failed."
+
+  except Exception as err:
+    print "Error-trace replay caught", err.message
+
+  return False
 
 
 def detect_missing_definitions(bc_file):

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -70,7 +70,7 @@ def aggregate_values(stream):
       _, fn = key.split(':')
       arguments[fn] = []
 
-    if 'arg:' in key:
+    elif 'arg:' in key:
       _, fn, arg = key.split(':')
       if not fn in arguments:
         raise Exception("expected entry point key smack:entry:%s" % fn)
@@ -125,7 +125,12 @@ int %(fn)s() {
 """ % {'fn': fn, 'vals': ", ".join(return_values[fn])})
 
     else:
-      print "warning: cannot generate stub for %s" % fn
+      print "warning: unknown return value for %s" % fn
+      code.append("""// stub for function %(fn)s
+void %(fn)s() {
+  return;
+}
+""" % {'fn': fn})
 
   for fn in set(return_values) - set(missing_definitions):
     print "warning: using native implementation of function %s" % fn

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -59,26 +59,25 @@ def extract_values(stream):
 
 
 def aggregate_values(stream):
-  dict = {}
-  for line in stream:
-    fn, val = line.strip().split(",")
-    fn = fn.replace('SMACK_nondet', 'VERIFIER_nondet')
-    if not fn in dict:
-        dict[fn] = []
-    dict[fn].append(val)
-
   arguments = {}
   return_values = {}
 
-  for key, vals in dict.items():
-    if 'ext:' in key:
-      _, fn = key.split(':')
-      return_values[fn] = vals
-    elif 'arg:' in key:
+  for line in stream:
+    key, val = line.strip().split(",")
+    key = key.replace('SMACK_nondet', 'VERIFIER_nondet')
+
+    if 'arg:' in key:
       _, fn, arg = key.split(':')
       if not fn in arguments:
-        arguments[fn] = {}
-      arguments[fn][arg] = vals[0]
+        arguments[fn] = []
+      arguments[fn].append(val)
+
+    elif 'ext:' in key:
+      _, fn = key.split(':')
+      if not fn in return_values:
+        return_values[fn] = []
+      return_values[fn].append(val)
+
     else:
       print "warning: unexpected key %s" % key
 
@@ -139,6 +138,6 @@ int smack_replay_main() {
   %(fn)s(%(vals)s);
   return 0;
 }
-""" % {'fn': fn, 'vals': ", ".join(args.values())})
+""" % {'fn': fn, 'vals': ", ".join(args)})
 
   return "\n".join(code)

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -1,11 +1,8 @@
 import os
+import re
 import subprocess
 import sys
 from utils import temporary_file, try_command
-
-STUBBABLE_FUNCTIONS = [
-  "__VERIFIER_nondet"
-]
 
 def replay_error_trace(verifier_output, args):
 
@@ -17,15 +14,23 @@ def replay_error_trace(verifier_output, args):
     print "Replay for verifiers other than 'corral' currently unsupported; skipping replay"
     return
 
+  stubs_bc = temporary_file('stubs', '.bc', args)
+  missing_definitions = []
+
+  try:
+    try_command(['clang', '-o', args.replay_exe_file, args.bc_file])
+  except Exception as err:
+    missing_definitions = detect_missing_definitions(err[1])
+
   read, write = os.pipe()
   os.write(write, verifier_output)
   os.close(write)
   with open(args.replay_harness, 'w') as f:
-    f.write(stub_module(aggregate_values(collect_returns(read))))
+    f.write(stub_module(aggregate_values(collect_returns(read)), missing_definitions))
 
-  stubs_bc = temporary_file('stubs', '.bc', args)
   try_command(['clang', '-c', '-emit-llvm', '-o', stubs_bc, args.replay_harness])
   try_command(['clang', '-o', args.replay_exe_file, args.bc_file, stubs_bc])
+
   print "Generated replay harness:", args.replay_harness
   print "Generated replay executable:", args.replay_exe_file
 
@@ -39,25 +44,30 @@ def replay_error_trace(verifier_output, args):
 def collect_returns(stream):
   return reduce(
   (lambda s, c: subprocess.Popen(c, stdin=s, stdout=subprocess.PIPE).stdout), [
-    ["grep", "-A", "1", "-e", "RETURN from \(%s\)" % "\|".join(STUBBABLE_FUNCTIONS)],
-    ["sed", "s/.*  (\(.*\))/\\1/"],
-    ["cut", "-d", " ", "-f3"],
-    ["grep", "-v", "-e", "--"],
-    ["paste", "-d,", "-", "-"]
+    ["grep", "ext:"],
+    ["sed", "s/.*ext:\(.*\) = \(.*\))/\\1,\\2/"]
   ], stream)
 
+def detect_missing_definitions(failed_clang_output):
+  missing = []
+  for line in failed_clang_output.split("\n"):
+    m = re.search(r'\"_(.*)\", referenced from:', line)
+    if m:
+      missing.append(m.group(1))
+  return missing
 
 def aggregate_values(stream):
   dict = {}
   for line in stream:
     fn, val = line.strip().split(",")
+    fn = fn.replace('SMACK_nondet', 'VERIFIER_nondet')
     if not fn in dict:
         dict[fn] = []
     dict[fn].append(val)
   return dict
 
 
-def stub_module(dict):
+def stub_module(dict, missing_definitions):
   code = []
   code.append("""//
 // This file was automatically generated from a Boogie error trace.
@@ -83,6 +93,9 @@ void __VERIFIER_assume(int b) {
 """)
 
   for fn, vals in dict.items():
+    if not fn in missing_definitions:
+      continue
+
     code.append("""// stub for function: %(fn)s
 int %(fn)s$table[] = {%(vals)s};
 int %(fn)s$idx = 0;

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -135,9 +135,6 @@ void %(fn)s() {
 }
 """ % {'fn': fn})
 
-  for fn in set(return_values) - set(missing_definitions):
-    print "warning: using native implementation of function %s" % fn
-
   if len(arguments) > 1:
     print "warning: multiple entrypoint argument annotations found"
 

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -146,6 +146,10 @@ void %(fn)s() {
 
   for fn, args in arguments.items():
     code.append("""// entry point wrapper
+int _smack_replay_main() {
+  %(fn)s(%(vals)s);
+  return 0;
+}
 int smack_replay_main() {
   %(fn)s(%(vals)s);
   return 0;

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -6,17 +6,13 @@ import os
 import platform
 import re
 import shutil
-import signal
-import subprocess
 import sys
-import tempfile
-from threading import Timer
 from svcomp.utils import svcomp_frontend
 from svcomp.utils import verify_bpl_svcomp
+from utils import temporary_file, try_command, remove_temp_files
 from replay import replay_error_trace
 
 VERSION = '1.7.2'
-temporary_files = []
 
 def frontends():
   """A dictionary of front-ends per file extension."""
@@ -110,6 +106,15 @@ def arguments():
 
   frontend_group.add_argument('-bc', '--bc-file', metavar='FILE', default=None,
     type=str, help='save initial LLVM bitcode to FILE')
+
+  frontend_group.add_argument('--linked-bc-file', metavar='FILE', default=None,
+    type=str, help=argparse.SUPPRESS)
+
+  frontend_group.add_argument('--replay-harness', metavar='FILE', default='replay-harness.c',
+    type=str, help=argparse.SUPPRESS)
+
+  frontend_group.add_argument('--replay-exe-file', metavar='FILE', default='replay-exe',
+    type=str, help=argparse.SUPPRESS)
 
   frontend_group.add_argument('-ll', '--ll-file', metavar='FILE', default=None,
     type=str, help='save final LLVM IR to FILE')
@@ -208,6 +213,9 @@ def arguments():
   if not args.bc_file:
     args.bc_file = temporary_file('a', '.bc', args)
 
+  if not args.linked_bc_file:
+    args.linked_bc_file = temporary_file('b', '.bc', args)
+
   if not args.bpl_file:
     args.bpl_file = 'a.bpl' if args.no_verify else temporary_file('a', '.bpl', args)
 
@@ -222,71 +230,6 @@ def arguments():
   #       return args = parser.parse_args(m.group(1).split() + sys.argv[1:])
 
   return args
-
-def temporary_file(prefix, extension, args):
-  f, name = tempfile.mkstemp(extension, prefix + '-', os.getcwd(), True)
-  os.close(f)
-  if not args.debug:
-    temporary_files.append(name)
-  return name
-
-def timeout_killer(proc, timed_out):
-  if not timed_out[0]:
-    timed_out[0] = True
-    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-
-def try_command(cmd, cwd=None, console=False, timeout=None):
-  console = (console or args.verbose or args.debug) and not args.quiet
-  filelog = args.debug
-  output = ''
-  proc = None
-  timer = None
-  try:
-    if args.debug:
-      print "Running %s" % " ".join(cmd)
-
-    proc = subprocess.Popen(cmd, cwd=cwd, preexec_fn=os.setsid,
-      stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-
-    if timeout:
-      timed_out = [False]
-      timer = Timer(timeout, timeout_killer, [proc, timed_out])
-      timer.start()
-
-    if console:
-      while True:
-        line = proc.stdout.readline()
-        if line:
-          output += line
-          print line,
-        elif proc.poll() is not None:
-          break
-      proc.wait
-    else:
-      output = proc.communicate()[0]
-
-    if timeout:
-      timer.cancel()
-
-    rc = proc.returncode
-    proc = None
-    if timeout and timed_out[0]:
-      return output + ("\n%s timed out." % cmd[0])
-    elif rc:
-      raise RuntimeError("%s returned non-zero." % cmd[0])
-    else:
-      return output
-
-  except (RuntimeError, OSError) as err:
-    print >> sys.stderr, output
-    sys.exit("Error invoking command:\n%s\n%s" % (" ".join(cmd), err))
-
-  finally:
-    if timeout and timer: timer.cancel()
-    if proc: os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-    if filelog:
-      with open(temporary_file(cmd[0], '.log', args), 'w') as f:
-        f.write(output)
 
 def target_selection(args):
   """Determine the target architecture based on flags and source files."""
@@ -360,14 +303,14 @@ def boogie_frontend(args):
 def llvm_frontend(args):
   """Generate Boogie code from LLVM bitcodes."""
 
-  bitcodes = build_libs(args) + args.input_files
-  try_command(['llvm-link', '-o', args.bc_file] + bitcodes)
+  try_command(['llvm-link', '-o', args.bc_file] + args.input_files)
+  try_command(['llvm-link', '-o', args.linked_bc_file, args.bc_file] + build_libs(args))
   llvm_to_bpl(args)
 
 def clang_frontend(args):
   """Generate Boogie code from C-language source(s)."""
 
-  bitcodes = build_libs(args)
+  bitcodes = []
   compile_command = default_clang_compile_command(args)
 
   for c in args.input_files:
@@ -376,6 +319,7 @@ def clang_frontend(args):
     bitcodes.append(bc)
 
   try_command(['llvm-link', '-o', args.bc_file] + bitcodes)
+  try_command(['llvm-link', '-o', args.linked_bc_file, args.bc_file] + build_libs(args))
   llvm_to_bpl(args)
 
 def json_compilation_database_frontend(args):
@@ -387,14 +331,13 @@ def json_compilation_database_frontend(args):
   output_flags = re.compile(r"-o ([^ ]*)[.]o\b")
   optimization_flags = re.compile(r"-O[1-9]\b")
 
-  lib_bitcodes = build_libs(args)
-
   with open(args.input_files[0]) as f:
     for cc in json.load(f):
       if 'objects' in cc:
         # TODO what to do when there are multiple linkings?
         bit_codes = map(lambda f: re.sub('[.]o$','.bc',f), cc['objects'])
-        try_command(['llvm-link', '-o', args.bc_file] + bit_codes + lib_bitcodes)
+        try_command(['llvm-link', '-o', args.bc_file] + bit_codes)
+        try_command(['llvm-link', '-o', args.linked_bc_file, args.bc_file] + build_libs(args))
 
       else:
         out_file = output_flags.findall(cc['command'])[0] + '.bc'
@@ -409,7 +352,7 @@ def json_compilation_database_frontend(args):
 def llvm_to_bpl(args):
   """Translate the LLVM bitcode file to a Boogie source file."""
 
-  cmd = ['llvm2bpl', args.bc_file, '-bpl', args.bpl_file]
+  cmd = ['llvm2bpl', args.linked_bc_file, '-bpl', args.bpl_file]
   cmd += ['-warnings']
   cmd += ['-source-loc-syms']
   for ep in args.entry_points:
@@ -569,7 +512,7 @@ def verify_bpl(args):
         print error
 
       if args.replay:
-         replay_error_trace(verifier_output)
+         replay_error_trace(verifier_output, args)
 
     sys.exit(results(args)[result])
 
@@ -684,6 +627,4 @@ def main():
     sys.exit("SMACK aborted by keyboard interrupt.")
 
   finally:
-    for f in temporary_files:
-      if os.path.isfile(f):
-        os.unlink(f)
+    remove_temp_files()

--- a/share/smack/utils.py
+++ b/share/smack/utils.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import tempfile
+import subprocess
+import signal
+from threading import Timer
+import top
+
+temporary_files = []
+
+def temporary_file(prefix, extension, args):
+  f, name = tempfile.mkstemp(extension, prefix + '-', os.getcwd(), True)
+  os.close(f)
+  if not args.debug:
+    temporary_files.append(name)
+  return name
+
+def remove_temp_files():
+  for f in temporary_files:
+    if os.path.isfile(f):
+      os.unlink(f)
+
+def timeout_killer(proc, timed_out):
+  if not timed_out[0]:
+    timed_out[0] = True
+    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+
+def try_command(cmd, cwd=None, console=False, timeout=None):
+  args = top.args
+  console = (console or args.verbose or args.debug) and not args.quiet
+  filelog = args.debug
+  output = ''
+  proc = None
+  timer = None
+  try:
+    if args.debug:
+      print "Running %s" % " ".join(cmd)
+
+    proc = subprocess.Popen(cmd, cwd=cwd, preexec_fn=os.setsid,
+      stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    if timeout:
+      timed_out = [False]
+      timer = Timer(timeout, timeout_killer, [proc, timed_out])
+      timer.start()
+
+    if console:
+      while True:
+        line = proc.stdout.readline()
+        if line:
+          output += line
+          print line,
+        elif proc.poll() is not None:
+          break
+      proc.wait
+    else:
+      output = proc.communicate()[0]
+
+    if timeout:
+      timer.cancel()
+
+    rc = proc.returncode
+    proc = None
+    if timeout and timed_out[0]:
+      return output + ("\n%s timed out." % cmd[0])
+    elif rc:
+      raise RuntimeError("%s returned non-zero." % cmd[0])
+    else:
+      return output
+
+  except (RuntimeError, OSError) as err:
+    print >> sys.stderr, output
+    sys.exit("Error invoking command:\n%s\n%s" % (" ".join(cmd), err))
+
+  finally:
+    if timeout and timer: timer.cancel()
+    if proc: os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    if filelog:
+      with open(temporary_file(cmd[0], '.log', args), 'w') as f:
+        f.write(output)

--- a/share/smack/utils.py
+++ b/share/smack/utils.py
@@ -64,7 +64,7 @@ def try_command(cmd, cwd=None, console=False, timeout=None):
     if timeout and timed_out[0]:
       return output + ("\n%s timed out." % cmd[0])
     elif rc:
-      raise Exception("%s returned non-zero." % cmd[0], output)
+      raise Exception(output)
     else:
       return output
 

--- a/share/smack/utils.py
+++ b/share/smack/utils.py
@@ -64,7 +64,7 @@ def try_command(cmd, cwd=None, console=False, timeout=None):
     if timeout and timed_out[0]:
       return output + ("\n%s timed out." % cmd[0])
     elif rc:
-      raise RuntimeError("%s returned non-zero." % cmd[0])
+      raise Exception("%s returned non-zero." % cmd[0], output)
     else:
       return output
 

--- a/share/smack/utils.py
+++ b/share/smack/utils.py
@@ -63,6 +63,8 @@ def try_command(cmd, cwd=None, console=False, timeout=None):
     proc = None
     if timeout and timed_out[0]:
       return output + ("\n%s timed out." % cmd[0])
+    elif rc == -signal.SIGSEGV:
+      raise Exception("segmentation fault")
     elif rc:
       raise Exception(output)
     else:


### PR DESCRIPTION
This adds the basic capability to check whether counterexamples returned by Corral are executable, by generating a test harness providing the required inputs to the entry-point procedure, and stubs providing the required return values from special procedures like `__VERIFIER_nondet_int`. This is turned on with a single `--replay` flag.