### PR TITLE
Removing function calls internal to SMACK from DSA

### DIFF
--- a/lib/DSA/StdLibPass.cpp
+++ b/lib/DSA/StdLibPass.cpp
@@ -442,7 +442,7 @@ const struct {
 
 // SMACK functions that are excluded from DSA
 Regex SMACK_PROC_IGNORE("^("
-  "__SMACK_code|__SMACK_mod|__SMACK_decl|__SMACK_top_decl|"
+  "__SMACK_mod|__SMACK_decl|__SMACK_top_decl|"
   "__SMACK_values|__SMACK_check_memory_safety"
 ")$");
 

--- a/lib/DSA/StdLibPass.cpp
+++ b/lib/DSA/StdLibPass.cpp
@@ -442,7 +442,7 @@ const struct {
 
 // SMACK functions that are excluded from DSA
 Regex SMACK_PROC_IGNORE("^("
-  "__SMACK_mod|__SMACK_decl|__SMACK_top_decl|"
+  "__SMACK_code|__SMACK_mod|__SMACK_decl|__SMACK_top_decl|"
   "__SMACK_values|__SMACK_check_memory_safety"
 ")$");
 

--- a/lib/smack/MemorySafetyChecker.cpp
+++ b/lib/smack/MemorySafetyChecker.cpp
@@ -26,7 +26,7 @@ void insertMemoryLeakCheck(Function& F, Module& m) {
   }
 }
 
-void inserMemoryAccessCheck(Value* memoryPointer, Instruction* I, DataLayout* dataLayout, Function* memorySafetyFunction, Function* F) {
+void insertMemoryAccessCheck(Value* memoryPointer, Instruction* I, DataLayout* dataLayout, Function* memorySafetyFunction, Function* F) {
   // Finding the exact type of the second argument to our memory safety function
   Type* sizeType = memorySafetyFunction->getFunctionType()->getParamType(1);
   PointerType* pointerType = cast<PointerType>(memoryPointer->getType());
@@ -49,9 +49,9 @@ bool MemorySafetyChecker::runOnModule(Module& m) {
       }
       for (inst_iterator I = inst_begin(F), E = inst_end(F); I != E; ++I) {
         if (LoadInst* li = dyn_cast<LoadInst>(&*I)) {
-          inserMemoryAccessCheck(li->getPointerOperand(), &*I, dataLayout, memorySafetyFunction, &F);
+          insertMemoryAccessCheck(li->getPointerOperand(), &*I, dataLayout, memorySafetyFunction, &F);
         } else if (StoreInst* si = dyn_cast<StoreInst>(&*I)) {
-          inserMemoryAccessCheck(si->getPointerOperand(), &*I, dataLayout, memorySafetyFunction, &F);
+          insertMemoryAccessCheck(si->getPointerOperand(), &*I, dataLayout, memorySafetyFunction, &F);
         } else if (MemSetInst* memseti = dyn_cast<MemSetInst>(&*I)) {
 	    Value* dest = memseti->getDest();
 	    Value* size = memseti->getLength();

--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -23,10 +23,10 @@ extern "C" {
 // For handling of va_start macro
 void __builtinx_va_start(char*,char*);
 
-void __SMACK_code(const char *fmt, ...);
-void __SMACK_mod(const char *fmt, ...);
-void __SMACK_decl(const char *fmt, ...);
-void __SMACK_top_decl(const char *fmt, ...);
+const void __SMACK_code(const char *fmt, ...);
+const void __SMACK_mod(const char *fmt, ...);
+const void __SMACK_decl(const char *fmt, ...);
+const void __SMACK_top_decl(const char *fmt, ...);
 
 typedef struct smack_value { void* dummy; }* smack_value_t;
 smack_value_t __SMACK_value();

--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -23,10 +23,10 @@ extern "C" {
 // For handling of va_start macro
 void __builtinx_va_start(char*,char*);
 
-const void __SMACK_code(const char *fmt, ...);
-const void __SMACK_mod(const char *fmt, ...);
-const void __SMACK_decl(const char *fmt, ...);
-const void __SMACK_top_decl(const char *fmt, ...);
+void __SMACK_code(const char *fmt, ...);
+void __SMACK_mod(const char *fmt, ...);
+void __SMACK_decl(const char *fmt, ...);
+void __SMACK_top_decl(const char *fmt, ...);
 
 typedef struct smack_value { void* dummy; }* smack_value_t;
 smack_value_t __SMACK_value();


### PR DESCRIPTION
Removing calls to functions such as `__SMACK_code` and `__SMACK_check_memory_safety` from being analyzed by DSA. These functions are internal to SMACK and are noops as far as DSA is considered. Removing them prevents merging of nodes and makes DSA more precise.