### PR TITLE
Added assumption to alloc that size is not negative

### DIFF
--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -2034,7 +2034,9 @@ void __SMACK_decls() {
   D("procedure $malloc(n: ref) returns (p: ref)\n"
     "modifies $allocatedCounter;\n"
     "{\n"
-    "  $allocatedCounter := $allocatedCounter + 1;\n"
+    "  if ($ne.ref.bool(n, $0.ref)) {\n"
+    "    $allocatedCounter := $allocatedCounter + 1;\n"
+    "  }\n"
     "  call p := $$alloc(n);\n"
     "}\n");
 

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -2055,8 +2055,8 @@ void __SMACK_decls() {
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref)\n"
     "modifies $Alloc, $CurrAddr;\n"
     "{\n"
-    "  assume $sge.ref.bool(n, $0.ref);\n"
-    "  if ($sgt.ref.bool(n, $0.ref)) {\n"
+    "  assume $sle.ref.bool($0.ref, n);\n"
+    "  if ($slt.ref.bool($0.ref, n)) {\n"
     "    p := $CurrAddr;\n"
     "    havoc $CurrAddr;\n"
     "    assume $sle.ref.bool($add.ref(p, n), $CurrAddr);\n"
@@ -2073,8 +2073,8 @@ void __SMACK_decls() {
     "{\n"
     "  if ($ne.ref.bool(p, $0.ref)) {\n"
     "    assert {:valid_free} $eq.ref.bool($base(p), p);\n"
-    "    assert {:valid_free} $Alloc[p] == true;\n"
-    "    assert {:valid_free} $sgt.ref.bool(p, $0.ref);\n"
+    "    assert {:valid_free} $Alloc[p];\n"
+    "    assert {:valid_free} $slt.ref.bool($0.ref, p);\n"
     "    $Alloc[p] := false;\n"
     "    $allocatedCounter := $allocatedCounter - 1;\n"
     "  }\n"
@@ -2085,7 +2085,7 @@ void __SMACK_decls() {
   D("var $Size: [ref] ref;\n");
 
   D("procedure $galloc(base_addr: ref, size: ref);\n"
-    "modifies $Alloc, $Size;"
+    "modifies $Alloc, $Size;\n"
     "ensures $Size[base_addr] == size;\n"
     "ensures (forall addr: ref :: {$base(addr)} $sle.ref.bool(base_addr, addr) && $slt.ref.bool(addr, $add.ref(base_addr, size)) ==> $base(addr) == base_addr);\n"
     "ensures $Alloc[base_addr];\n"
@@ -2094,11 +2094,11 @@ void __SMACK_decls() {
 
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref);\n"
     "modifies $Alloc, $Size;\n"
-    "free requires $sge.ref.bool(n, $0.ref);\n"
-    "ensures $sgt.ref.bool(n, $0.ref) ==> $sgt.ref.bool(p, $0.ref) && $slt.ref.bool(p, $MALLOC_TOP);\n"
+    "ensures $sle.ref.bool($0.ref, n);\n"
+    "ensures $slt.ref.bool($0.ref, n) ==> $slt.ref.bool($0.ref, p) && $slt.ref.bool(p, $MALLOC_TOP);\n"
     "ensures $eq.ref.bool(n, $0.ref) ==> p == $0.ref;\n"
     "ensures !old($Alloc[p]);\n"
-    "ensures (forall q: ref :: old($Alloc[q]) ==> ($slt.ref.bool($add.ref(p, n), q) || $sgt.ref.bool(p, $add.ref(q, $Size[q]))));\n"
+    "ensures (forall q: ref :: old($Alloc[q]) ==> ($slt.ref.bool($add.ref(p, n), q) || $slt.ref.bool($add.ref(q, $Size[q]), p)));\n"
     "ensures $Alloc[p];\n"
     "ensures $Size[p] == n;\n"
     "ensures (forall q: ref :: {$Size[q]} q != p ==> $Size[q] == old($Size[q]));\n"
@@ -2108,7 +2108,7 @@ void __SMACK_decls() {
   D("procedure $free(p: ref);\n"
     "modifies $Alloc, $allocatedCounter;\n"
     "requires $eq.ref.bool(p, $0.ref) || ($eq.ref.bool($base(p), p) && $Alloc[p]);\n"
-    "requires $sgt.ref.bool(p, $0.ref);\n"
+    "requires $slt.ref.bool($0.ref, p);\n"
     "ensures $ne.ref.bool(p, $0.ref) ==> !$Alloc[p];\n"
     "ensures $ne.ref.bool(p, $0.ref) ==> (forall q: ref :: {$Alloc[q]} q != p ==> $Alloc[q] == old($Alloc[q]));\n"
     "ensures $ne.ref.bool(p, $0.ref) ==> $allocatedCounter == old($allocatedCounter) - 1;\n");
@@ -2119,7 +2119,7 @@ void __SMACK_decls() {
   D("var $CurrAddr:ref;\n");
 
   D("procedure $galloc(base_addr: ref, size: ref);\n"
-    "modifies $Alloc;"
+    "modifies $Alloc;\n"
     "ensures $Size(base_addr) == size;\n"
     "ensures (forall addr: ref :: {$base(addr)} $sle.ref.bool(base_addr, addr) && $slt.ref.bool(addr, $add.ref(base_addr, size)) ==> $base(addr) == base_addr);\n"
     "ensures $Alloc[base_addr];\n"
@@ -2127,11 +2127,11 @@ void __SMACK_decls() {
 
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref);\n"
     "modifies $Alloc, $CurrAddr;\n"
-    "free requires $sge.ref.bool(n, $0.ref);\n"
-    "ensures $sgt.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), n), $CurrAddr) && p == old($CurrAddr);\n"
-    "ensures $sgt.ref.bool(n, $0.ref) ==> $Size(p) == n;\n"
-    "ensures $sgt.ref.bool(n, $0.ref) ==> (forall q: ref :: {$base(q)} $sle.ref.bool(p, q) && $slt.ref.bool(q, $add.ref(p, n)) ==> $base(q) == p);\n"
-    "ensures $sgt.ref.bool(n, $0.ref) ==> $Alloc[p];\n"
+    "ensures $sle.ref.bool($0.ref, n);\n"
+    "ensures $slt.ref.bool($0.ref, n) ==> $sle.ref.bool($add.ref(old($CurrAddr), n), $CurrAddr) && p == old($CurrAddr);\n"
+    "ensures $slt.ref.bool($0.ref, n) ==> $Size(p) == n;\n"
+    "ensures $slt.ref.bool($0.ref, n) ==> (forall q: ref :: {$base(q)} $sle.ref.bool(p, q) && $slt.ref.bool(q, $add.ref(p, n)) ==> $base(q) == p);\n"
+    "ensures $slt.ref.bool($0.ref, n) ==> $Alloc[p];\n"
     "ensures $eq.ref.bool(n, $0.ref) ==> old($CurrAddr) == $CurrAddr && p == $0.ref;\n"
     "ensures $eq.ref.bool(n, $0.ref)==> $Alloc[p] == old($Alloc)[p];\n"
     "ensures (forall q: ref :: {$Alloc[q]} q != p ==> $Alloc[q] == old($Alloc[q]));\n");
@@ -2139,7 +2139,7 @@ void __SMACK_decls() {
   D("procedure $free(p: ref);\n"
     "modifies $Alloc, $allocatedCounter;\n"
     "requires $eq.ref.bool(p, $0.ref) || ($eq.ref.bool($base(p), p) && $Alloc[p]);\n"
-    "requires $sgt.ref.bool(p, $0.ref);\n"
+    "requires $slt.ref.bool($0.ref, p);\n"
     "ensures $ne.ref.bool(p, $0.ref) ==> !$Alloc[p];\n"
     "ensures $ne.ref.bool(p, $0.ref) ==> (forall q: ref :: {$Alloc[q]} q != p ==> $Alloc[q] == old($Alloc[q]));\n"
     "ensures $ne.ref.bool(p, $0.ref) ==> $allocatedCounter == old($allocatedCounter) - 1;\n");
@@ -2175,11 +2175,11 @@ void __SMACK_decls() {
 
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref);\n"
     "modifies $Alloc, $Size;\n"
-    "free requires $sge.ref.bool(n, $0.ref);\n"
-    "ensures $sgt.ref.bool(n, $0.ref) ==> $sgt.ref.bool(p, $0.ref) && $slt.ref.bool(p, $MALLOC_TOP);\n"
+    "ensures $sle.ref.bool($0.ref, n);\n"
+    "ensures $slt.ref.bool($0.ref, n) ==> $slt.ref.bool($0.ref, p) && $slt.ref.bool(p, $MALLOC_TOP);\n"
     "ensures $eq.ref.bool(n, $0.ref) ==> p == $0.ref;\n"
     "ensures !old($Alloc[p]);\n"
-    "ensures (forall q: ref :: old($Alloc[q]) ==> ($slt.ref.bool($add.ref(p, n), q) || $sgt.ref.bool(p, $add.ref(q, $Size[q]))));\n"
+    "ensures (forall q: ref :: old($Alloc[q]) ==> ($slt.ref.bool($add.ref(p, n), q) || $slt.ref.bool($add.ref(q, $Size[q]), p)));\n"
     "ensures $Alloc[p];\n"
     "ensures $Size[p] == n;\n"
     "ensures (forall q: ref :: {$Size[q]} q != p ==> $Size[q] == old($Size[q]));\n"
@@ -2195,8 +2195,8 @@ void __SMACK_decls() {
 
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref);\n"
     "modifies $CurrAddr;\n"
-    "free requires $sge.ref.bool(n, $0.ref);\n"
-    "ensures $sgt.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), n), $CurrAddr) && p == old($CurrAddr);\n"
+    "ensures $sle.ref.bool($0.ref, n);\n"
+    "ensures $slt.ref.bool($0.ref, n) ==> $sle.ref.bool($add.ref(old($CurrAddr), n), $CurrAddr) && p == old($CurrAddr);\n"
     "ensures $eq.ref.bool(n, $0.ref) ==> old($CurrAddr) == $CurrAddr && p == $0.ref;\n");
 
   D("procedure $free(p: ref);\n");
@@ -2210,7 +2210,7 @@ void __SMACK_decls() {
 // The size parameter represents number of bytes that are being accessed
 void __SMACK_check_memory_safety(void* pointer, unsigned long size) {
   void* sizeRef = (void*)size;
-  __SMACK_code("assert {:valid_deref} $Alloc[$base(@)] == true;", pointer);
+  __SMACK_code("assert {:valid_deref} $Alloc[$base(@)];", pointer);
   __SMACK_code("assert {:valid_deref} $sle.ref.bool($base(@), @);", pointer, pointer);
 #if MEMORY_MODEL_NO_REUSE_IMPLS
   __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size($base(@))));", pointer, sizeRef, pointer, pointer);

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -2053,18 +2053,17 @@ void __SMACK_decls() {
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref)\n"
     "modifies $Alloc, $CurrAddr;\n"
     "{\n"
-    "  p := $CurrAddr;\n"
-    "  havoc $CurrAddr;\n"
+    "  assume $sge.ref.bool(n, $0.ref);\n"
     "  if ($sgt.ref.bool(n, $0.ref)) {\n"
+    "    p := $CurrAddr;\n"
+    "    havoc $CurrAddr;\n"
     "    assume $sle.ref.bool($add.ref(p, n), $CurrAddr);\n"
     "    assume $Size(p) == n;\n"
     "    assume (forall q: ref :: {$base(q)} $sle.ref.bool(p, q) && $slt.ref.bool(q, $add.ref(p, n)) ==> $base(q) == p);\n"
+    "    $Alloc[p] := true;\n"
     "  } else {\n"
-    "    assume $sle.ref.bool($add.ref(p, $1.ref), $CurrAddr);\n"
-    "    assume $Size(p) == $1.ref;\n"
-    "    assume $eq.ref.bool($base(p), p);\n"
+    "    p := $0.ref;\n"
     "  }\n"
-    "  $Alloc[p] := true;\n"
     "}\n");
 
   D("procedure $free(p: ref)\n"
@@ -2093,6 +2092,7 @@ void __SMACK_decls() {
 
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref);\n"
     "modifies $Alloc, $Size;\n"
+    "free requires $sge.ref.bool(n, $0.ref);\n"
     "ensures $sgt.ref.bool(p, $0.ref);\n"
     "ensures $slt.ref.bool(p, $MALLOC_TOP);\n"
     "ensures !old($Alloc[p]);\n"
@@ -2101,7 +2101,7 @@ void __SMACK_decls() {
     "ensures $Size[p] == n;\n"
     "ensures (forall q: ref :: {$Size[q]} q != p ==> $Size[q] == old($Size[q]));\n"
     "ensures (forall q: ref :: {$Alloc[q]} q != p ==> $Alloc[q] == old($Alloc[q]));\n"
-    "ensures $sge.ref.bool(n, $0.ref) ==> (forall q: ref :: {$base(q)} $sle.ref.bool(p, q) && $slt.ref.bool(q, $add.ref(p, n)) ==> $base(q) == p);\n");
+    "ensures (forall q: ref :: {$base(q)} $sle.ref.bool(p, q) && $slt.ref.bool(q, $add.ref(p, n)) ==> $base(q) == p);\n");
 
   D("procedure $free(p: ref);\n"
     "modifies $Alloc, $allocatedCounter;\n"
@@ -2125,13 +2125,14 @@ void __SMACK_decls() {
 
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref);\n"
     "modifies $Alloc, $CurrAddr;\n"
+    "free requires $sge.ref.bool(n, $0.ref);\n"
     "ensures p == old($CurrAddr);\n"
     "ensures $sgt.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), n), $CurrAddr);\n"
     "ensures $sgt.ref.bool(n, $0.ref) ==> $Size(p) == n;\n"
     "ensures $sgt.ref.bool(n, $0.ref) ==> (forall q: ref :: {$base(q)} $sle.ref.bool(p, q) && $slt.ref.bool(q, $add.ref(p, n)) ==> $base(q) == p);\n"
-    "ensures !$sgt.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), $1.ref), $CurrAddr);\n"
-    "ensures !$sgt.ref.bool(n, $0.ref) ==> $Size(p) == $1.ref;\n"
-    "ensures !$sgt.ref.bool(n, $0.ref) ==> $eq.ref.bool($base(p), p);\n"
+    "ensures $eq.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), $1.ref), $CurrAddr);\n"
+    "ensures $eq.ref.bool(n, $0.ref) ==> $Size(p) == $1.ref;\n"
+    "ensures $eq.ref.bool(n, $0.ref) ==> $eq.ref.bool($base(p), p);\n"
     "ensures $Alloc[p];\n"
     "ensures (forall q: ref :: {$Alloc[q]} q != p ==> $Alloc[q] == old($Alloc[q]));\n");
 
@@ -2156,12 +2157,13 @@ void __SMACK_decls() {
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref)\n"
     "modifies $CurrAddr;\n"
     "{\n"
-    "  p := $CurrAddr;\n"
-    "  havoc $CurrAddr;\n"
+    "  assume $sge.ref.bool(n, $0.ref);\n"
     "  if ($sgt.ref.bool(n, $0.ref)) {\n"
+    "    p := $CurrAddr;\n"
+    "    havoc $CurrAddr;\n"
     "    assume $sle.ref.bool($add.ref(p, n), $CurrAddr);\n"
     "  } else {\n"
-    "    assume $sle.ref.bool($add.ref(p, $1.ref), $CurrAddr);\n"
+    "    p := $0.ref;\n"
     "  }\n"
     "}\n");
 
@@ -2173,6 +2175,7 @@ void __SMACK_decls() {
 
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref);\n"
     "modifies $Alloc, $Size;\n"
+    "free requires $sge.ref.bool(n, $0.ref);\n"
     "ensures $sgt.ref.bool(p, $0.ref);\n"
     "ensures $slt.ref.bool(p, $MALLOC_TOP);\n"
     "ensures !old($Alloc[p]);\n"
@@ -2192,9 +2195,10 @@ void __SMACK_decls() {
 
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref);\n"
     "modifies $CurrAddr;\n"
+    "free requires $sge.ref.bool(n, $0.ref);\n"
     "ensures p == old($CurrAddr);\n"
     "ensures $sgt.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), n), $CurrAddr);\n"
-    "ensures !$sgt.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), $1.ref), $CurrAddr);\n");
+    "ensures $eq.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), $1.ref), $CurrAddr);\n");
 
   D("procedure $free(p: ref);\n");
 #endif

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -2095,8 +2095,8 @@ void __SMACK_decls() {
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref);\n"
     "modifies $Alloc, $Size;\n"
     "free requires $sge.ref.bool(n, $0.ref);\n"
-    "ensures $sgt.ref.bool(p, $0.ref);\n"
-    "ensures $slt.ref.bool(p, $MALLOC_TOP);\n"
+    "ensures $sgt.ref.bool(n, $0.ref) ==> $sgt.ref.bool(p, $0.ref) && $slt.ref.bool(p, $MALLOC_TOP);\n"
+    "ensures $eq.ref.bool(n, $0.ref) ==> p == $0.ref;\n"
     "ensures !old($Alloc[p]);\n"
     "ensures (forall q: ref :: old($Alloc[q]) ==> ($slt.ref.bool($add.ref(p, n), q) || $sgt.ref.bool(p, $add.ref(q, $Size[q]))));\n"
     "ensures $Alloc[p];\n"
@@ -2128,14 +2128,12 @@ void __SMACK_decls() {
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref);\n"
     "modifies $Alloc, $CurrAddr;\n"
     "free requires $sge.ref.bool(n, $0.ref);\n"
-    "ensures p == old($CurrAddr);\n"
-    "ensures $sgt.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), n), $CurrAddr);\n"
+    "ensures $sgt.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), n), $CurrAddr) && p == old($CurrAddr);\n"
     "ensures $sgt.ref.bool(n, $0.ref) ==> $Size(p) == n;\n"
     "ensures $sgt.ref.bool(n, $0.ref) ==> (forall q: ref :: {$base(q)} $sle.ref.bool(p, q) && $slt.ref.bool(q, $add.ref(p, n)) ==> $base(q) == p);\n"
-    "ensures $eq.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), $1.ref), $CurrAddr);\n"
-    "ensures $eq.ref.bool(n, $0.ref) ==> $Size(p) == $1.ref;\n"
-    "ensures $eq.ref.bool(n, $0.ref) ==> $eq.ref.bool($base(p), p);\n"
-    "ensures $Alloc[p];\n"
+    "ensures $sgt.ref.bool(n, $0.ref) ==> $Alloc[p];\n"
+    "ensures $eq.ref.bool(n, $0.ref) ==> old($CurrAddr) == $CurrAddr && p == $0.ref;\n"
+    "ensures $eq.ref.bool(n, $0.ref)==> $Alloc[p] == old($Alloc)[p];\n"
     "ensures (forall q: ref :: {$Alloc[q]} q != p ==> $Alloc[q] == old($Alloc[q]));\n");
 
   D("procedure $free(p: ref);\n"
@@ -2178,8 +2176,8 @@ void __SMACK_decls() {
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref);\n"
     "modifies $Alloc, $Size;\n"
     "free requires $sge.ref.bool(n, $0.ref);\n"
-    "ensures $sgt.ref.bool(p, $0.ref);\n"
-    "ensures $slt.ref.bool(p, $MALLOC_TOP);\n"
+    "ensures $sgt.ref.bool(n, $0.ref) ==> $sgt.ref.bool(p, $0.ref) && $slt.ref.bool(p, $MALLOC_TOP);\n"
+    "ensures $eq.ref.bool(n, $0.ref) ==> p == $0.ref;\n"
     "ensures !old($Alloc[p]);\n"
     "ensures (forall q: ref :: old($Alloc[q]) ==> ($slt.ref.bool($add.ref(p, n), q) || $sgt.ref.bool(p, $add.ref(q, $Size[q]))));\n"
     "ensures $Alloc[p];\n"
@@ -2198,9 +2196,8 @@ void __SMACK_decls() {
   D("procedure {:inline 1} $$alloc(n: ref) returns (p: ref);\n"
     "modifies $CurrAddr;\n"
     "free requires $sge.ref.bool(n, $0.ref);\n"
-    "ensures p == old($CurrAddr);\n"
-    "ensures $sgt.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), n), $CurrAddr);\n"
-    "ensures $eq.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), $1.ref), $CurrAddr);\n");
+    "ensures $sgt.ref.bool(n, $0.ref) ==> $sle.ref.bool($add.ref(old($CurrAddr), n), $CurrAddr) && p == old($CurrAddr);\n"
+    "ensures $eq.ref.bool(n, $0.ref) ==> old($CurrAddr) == $CurrAddr && p == $0.ref;\n");
 
   D("procedure $free(p: ref);\n");
 #endif

--- a/test/memory-safety/malloc_nondet.c
+++ b/test/memory-safety/malloc_nondet.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+#include "smack.h"
+
+// @expect verified
+
+int main(void) {
+  int x = __VERIFIER_nondet_int();
+  char *p = (char*)malloc(x);
+  if (p != NULL) {
+    p[x-1] = x;
+    free(p);
+  }
+  return 0;
+}
+

--- a/test/memory-safety/malloc_nondet_fail.c
+++ b/test/memory-safety/malloc_nondet_fail.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+#include "smack.h"
+
+// @expect error
+
+int main(void) {
+  int x = __VERIFIER_nondet_int();
+  char *p = (char*)malloc(x);
+  if (p != NULL) {
+    p[x] = x;
+    free(p);
+  }
+  return 0;
+}
+


### PR DESCRIPTION
For some reason when size was negative we used to allocate an
object of size 1. This seems like a hack to me and I am not sure
why it was introduced in the first place. I cleaned this up now
by requiring that size is not negative, and blocking executions
with negative size.