### PR TITLE
Adding verifier-code metadata.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ add_library(smackTranslator STATIC
   include/smack/CodifyStaticInits.h
   include/smack/RemoveDeadDefs.h
   include/smack/ExtractContracts.h
+  include/smack/VerifierCodeMetadata.h
   include/smack/SimplifyLibCalls.h
   include/smack/SmackRep.h
   include/smack/MemorySafetyChecker.h
@@ -179,6 +180,7 @@ add_library(smackTranslator STATIC
   lib/smack/CodifyStaticInits.cpp
   lib/smack/RemoveDeadDefs.cpp
   lib/smack/ExtractContracts.cpp
+  lib/smack/VerifierCodeMetadata.cpp
   lib/smack/SimplifyLibCalls.cpp
   lib/smack/SmackRep.cpp
   lib/smack/MemorySafetyChecker.cpp

--- a/include/smack/VerifierCodeMetadata.h
+++ b/include/smack/VerifierCodeMetadata.h
@@ -1,0 +1,27 @@
+//
+// This file is distributed under the MIT License. See LICENSE for details.
+//
+
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+#include <queue>
+
+namespace smack {
+
+using namespace llvm;
+
+class VerifierCodeMetadata : public ModulePass, public InstVisitor<VerifierCodeMetadata> {
+private:
+  std::queue<Instruction*> workList;
+
+public:
+  static char ID;
+  VerifierCodeMetadata() : ModulePass(ID) {}
+  virtual bool runOnModule(Module& M);
+  virtual void getAnalysisUsage(AnalysisUsage &AU) const;
+  void visitCallInst(CallInst&);
+  void visitInstruction(Instruction&);
+};
+}

--- a/lib/smack/VerifierCodeMetadata.cpp
+++ b/lib/smack/VerifierCodeMetadata.cpp
@@ -51,10 +51,10 @@ namespace {
       if (N.find("__VERIFIER_") == 0)
         return true;
 
-      if (N.find("__SMACK") == 0)
+      if (N.find("__SMACK_") == 0)
         return true;
 
-      if (N.find("__CONTRACT") == 0)
+      if (N.find("__CONTRACT_") == 0)
         return true;
     }
     return false;

--- a/lib/smack/VerifierCodeMetadata.cpp
+++ b/lib/smack/VerifierCodeMetadata.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the MIT License. See LICENSE for details.
 //
 
-#define DEBUG_TYPE "contracts"
+#define DEBUG_TYPE "verifier-code-metadata"
 
 #include "smack/SmackOptions.h"
 #include "smack/Naming.h"

--- a/lib/smack/VerifierCodeMetadata.cpp
+++ b/lib/smack/VerifierCodeMetadata.cpp
@@ -1,0 +1,110 @@
+//
+// This file is distributed under the MIT License. See LICENSE for details.
+//
+
+#define DEBUG_TYPE "contracts"
+
+#include "smack/SmackOptions.h"
+#include "smack/Naming.h"
+#include "smack/VerifierCodeMetadata.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Dominators.h"
+
+#include <vector>
+#include <stack>
+#include <map>
+#include <set>
+
+namespace smack {
+
+using namespace llvm;
+
+namespace {
+  std::string getString(const llvm::Value* v) {
+    if (const llvm::ConstantExpr* constantExpr = llvm::dyn_cast<const llvm::ConstantExpr>(v))
+      if (constantExpr->getOpcode() == llvm::Instruction::GetElementPtr)
+        if (const llvm::GlobalValue* cc = llvm::dyn_cast<const llvm::GlobalValue>(constantExpr->getOperand(0)))
+          if (const llvm::ConstantDataSequential* cds = llvm::dyn_cast<const llvm::ConstantDataSequential>(cc->getOperand(0)))
+            return cds ->getAsCString();
+    return "";
+  }
+
+  void mark(Instruction &I, bool V = true) {
+    auto& C = I.getContext();
+    I.setMetadata("verifier.code",
+      MDNode::get(C, ConstantAsMetadata::get(
+        V ? ConstantInt::getTrue(C) : ConstantInt::getFalse(C)
+      )));
+  }
+
+  bool isMarked(Instruction& I) {
+    auto *N = I.getMetadata("verifier.code");
+    assert(N->getNumOperands() == 1);
+    auto *M = dyn_cast<ConstantAsMetadata>(N->getOperand(0).get());
+    auto *C = dyn_cast<ConstantInt>(M->getValue());
+    return C->isOne();
+  }
+}
+
+void VerifierCodeMetadata::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<DominatorTreeWrapperPass>();
+}
+
+bool VerifierCodeMetadata::runOnModule(Module &M) {
+  visit(M);
+  while (!workList.empty()) {
+    auto &I = *workList.front();
+    for (auto V : I.operand_values()) {
+      if (auto J = dyn_cast<Instruction>(V)) {
+        if (!isMarked(*J) && !dyn_cast<CallInst>(J)) {
+          auto onlyVerifierUsers = true;
+          std::queue<User*> users;
+          for (auto U : J->users())
+            users.push(U);
+
+          while (!users.empty()) {
+            if (auto K = dyn_cast<Instruction>(users.front())) {
+              if (!isMarked(*K)) {
+                onlyVerifierUsers = false;
+                break;
+              }
+            } else {
+              for (auto UU : users.front()->users())
+                users.push(UU);
+            }
+            users.pop();
+          }
+          if (onlyVerifierUsers) {
+            mark(*J);
+            workList.push(J);
+          }
+        }
+      }
+    }
+    workList.pop();
+  }
+  return true;
+}
+
+void VerifierCodeMetadata::visitCallInst(CallInst &I) {
+  if (auto F = I.getCalledFunction()) {
+    auto name = F->getName();
+    auto V = name.find("__VERIFIER_") == 0;
+    mark(I, V);
+    if (V) workList.push(&I);
+  }
+}
+
+void VerifierCodeMetadata::visitInstruction(Instruction &I) {
+  mark(I, false);
+}
+
+// Pass ID variable
+char VerifierCodeMetadata::ID = 0;
+
+// Register the pass
+static RegisterPass<VerifierCodeMetadata>
+X("verifier-code-metadata", "Verifier Code Metadata");
+
+}

--- a/lib/smack/VerifierCodeMetadata.cpp
+++ b/lib/smack/VerifierCodeMetadata.cpp
@@ -94,7 +94,6 @@ namespace {
 }
 
 void VerifierCodeMetadata::getAnalysisUsage(AnalysisUsage &AU) const {
-  AU.addRequired<DominatorTreeWrapperPass>();
 }
 
 bool VerifierCodeMetadata::runOnModule(Module &M) {

--- a/lib/smack/VerifierCodeMetadata.cpp
+++ b/lib/smack/VerifierCodeMetadata.cpp
@@ -5,15 +5,10 @@
 #define DEBUG_TYPE "verifier-code-metadata"
 
 #include "smack/SmackOptions.h"
-#include "smack/Naming.h"
 #include "smack/VerifierCodeMetadata.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/IR/DataLayout.h"
-#include "llvm/IR/Dominators.h"
 
-#include <vector>
-#include <stack>
-#include <map>
 #include <set>
 
 namespace smack {

--- a/tools/llvm2bpl/llvm2bpl.cpp
+++ b/tools/llvm2bpl/llvm2bpl.cpp
@@ -29,6 +29,7 @@
 #include "smack/CodifyStaticInits.h"
 #include "smack/RemoveDeadDefs.h"
 #include "smack/ExtractContracts.h"
+#include "smack/VerifierCodeMetadata.h"
 #include "smack/SimplifyLibCalls.h"
 #include "smack/MemorySafetyChecker.h"
 #include "smack/SignedIntegerOverflowChecker.h"
@@ -124,6 +125,7 @@ int main(int argc, char **argv) {
   pass_manager.add(new llvm::SimplifyEV());
   pass_manager.add(new llvm::SimplifyIV());
   pass_manager.add(new smack::ExtractContracts());
+  pass_manager.add(new smack::VerifierCodeMetadata());
   pass_manager.add(llvm::createDeadCodeEliminationPass());
   pass_manager.add(new smack::CodifyStaticInits());
   if (!Modular) {


### PR DESCRIPTION
Adds metadata annotations in LLVM bitcode to distinguish between “erasable” instructions that pertain only to verification, e.g., values feeding into `assume` and `assert` statements, and regular instructions that will actually be executed in the generated code.