### PR TITLE
Add support for constant structs being function returns

### DIFF
--- a/test/basic/struct_const_return.c
+++ b/test/basic/struct_const_return.c
@@ -3,21 +3,19 @@
 // @flag --clang-options=-O1
 // @expect verified
 
-typedef struct
-{
+typedef struct {
   int a;
   long b;
 } S;
 
-S foo()
-{
+S foo() {
   S x = {1, 2L};
   assert(1);
   return x;
 }
 
-int main()
-{
+int main() {
   S y = foo();
   assert(y.a == 1);
+  return 0;
 }

--- a/test/basic/struct_const_return.c
+++ b/test/basic/struct_const_return.c
@@ -1,0 +1,23 @@
+#include "smack.h"
+
+// @flag --clang-options=-O1
+// @expect verified
+
+typedef struct
+{
+  int a;
+  long b;
+} S;
+
+S foo()
+{
+  S x = {1, 2L};
+  assert(1);
+  return x;
+}
+
+int main()
+{
+  S y = foo();
+  assert(y.a == 1);
+}

--- a/test/basic/struct_const_return_fail.c
+++ b/test/basic/struct_const_return_fail.c
@@ -3,21 +3,19 @@
 // @flag --clang-options=-O1
 // @expect error 
 
-typedef struct
-{
+typedef struct {
   int a;
   long b;
 } S;
 
-S foo()
-{
+S foo() {
   S x = {1, 2L};
   assert(1);
   return x;
 }
 
-int main()
-{
+int main() {
   S y = foo();
   assert(y.a == 3);
+  return 0;
 }

--- a/test/basic/struct_const_return_fail.c
+++ b/test/basic/struct_const_return_fail.c
@@ -1,0 +1,23 @@
+#include "smack.h"
+
+// @flag --clang-options=-O1
+// @expect error 
+
+typedef struct
+{
+  int a;
+  long b;
+} S;
+
+S foo()
+{
+  S x = {1, 2L};
+  assert(1);
+  return x;
+}
+
+int main()
+{
+  S y = foo();
+  assert(y.a == 3);
+}


### PR DESCRIPTION
Consider the following example,

```LLVM
define { i32, i64 } @foo() {
  ret { i32, i64 } { i32 1, i64 2 }
}
```
It triggers an [assertion failure](https://github.com/smackers/smack/blob/master/lib/AssistDS/StructReturnToPointer.cpp#L114). This pull request intends to extend this pass to handle functions returning constant structs. It first allocates a place to hold the struct and then stores the constant into the space. For the example above, the PR converts the function body into the following form,

```LLVM
%1 = alloca { i32, i64 }
%2 = getelementptr { i32, i64 }, { i32, i64 }* %1, i32 0, i32 0
store i32 1, i32* %2
%3 = getelementptr { i32, i64 }, { i32, i64 }* %1, i32 0, i32 1
store i64 2, i64* %3        
%4 = load { i32, i64 }, { i32, i64 }* %1
ret { i32, i64 } %4
```
Note that this PR splits the struct constant once, which is unsound without PR #251.