### PR TITLE
Enable debugging.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ if (NOT WIN32 OR MSYS OR CYGWIN)
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
+  string(REPLACE "-DNDEBUG" "" LLVM_CXXFLAGS "${LLVM_CXXFLAGS}")
   string(REGEX REPLACE "-O[0-9]" "" CMAKE_CXX_FLAGS "${LLVM_CXXFLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-rtti")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
@@ -174,6 +175,7 @@ add_library(smackTranslator STATIC
   lib/smack/BoogieAst.cpp
   lib/smack/BplFilePrinter.cpp
   lib/smack/BplPrinter.cpp
+  lib/smack/Debug.cpp
   lib/smack/DSAWrapper.cpp
   lib/smack/Naming.cpp
   lib/smack/Regions.cpp

--- a/include/assistDS/DataStructureCallGraph.h
+++ b/include/assistDS/DataStructureCallGraph.h
@@ -20,7 +20,6 @@
 
 #include "llvm/IR/Module.h"
 #include "llvm/Analysis/CallGraph.h"
-#include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {

--- a/include/dsa/DSNode.h
+++ b/include/dsa/DSNode.h
@@ -17,7 +17,6 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/ilist_node.h"
 #include "llvm/ADT/ilist.h"
-#include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include "dsa/svset.h"
 #include "dsa/super_set.h"

--- a/include/smack/Debug.h
+++ b/include/smack/Debug.h
@@ -1,0 +1,38 @@
+//
+// This file is distributed under the MIT License. See LICENSE for details.
+//
+
+#ifndef SMACK_DEBUG_H
+#define SMACK_DEBUG_H
+
+#include "llvm/Support/raw_ostream.h"
+
+namespace smack {
+
+#ifndef NDEBUG
+
+bool isCurrentDebugType(const char *Type);
+void setCurrentDebugType(const char *Type);
+void setCurrentDebugTypes(const char **Types, unsigned Count);
+
+#define SMACK_DEBUG_WITH_TYPE(TYPE, X)                                        \
+  do { if (::smack::DebugFlag && ::smack::isCurrentDebugType(TYPE)) { X; } \
+  } while (false)
+
+#else
+#define isCurrentDebugType(X) (false)
+#define setCurrentDebugType(X)
+#define setCurrentDebugTypes(X, N)
+#define SMACK_DEBUG_WITH_TYPE(TYPE, X) do { } while (false)
+#endif
+
+extern bool DebugFlag;
+
+llvm::raw_ostream &dbgs();
+
+#undef DEBUG
+#define DEBUG(X) SMACK_DEBUG_WITH_TYPE(DEBUG_TYPE, X)
+
+}
+
+#endif

--- a/include/smack/SmackModuleGenerator.h
+++ b/include/smack/SmackModuleGenerator.h
@@ -10,7 +10,6 @@
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
 #include "llvm/Support/GraphWriter.h"
 #include <sstream>
 #include <stack>

--- a/include/smack/SmackRep.h
+++ b/include/smack/SmackRep.h
@@ -11,7 +11,6 @@
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/InstrTypes.h"
-#include "llvm/Support/Debug.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/Support/GraphWriter.h"
 #include "llvm/Support/Regex.h"

--- a/lib/AssistDS/ArgCast.cpp
+++ b/lib/AssistDS/ArgCast.cpp
@@ -19,7 +19,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 
 #include <set>
 #include <map>

--- a/lib/AssistDS/ArgSimplify.cpp
+++ b/lib/AssistDS/ArgSimplify.cpp
@@ -15,7 +15,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 
 #include <set>
 #include <map>

--- a/lib/AssistDS/DSNodeEquivs.cpp
+++ b/lib/AssistDS/DSNodeEquivs.cpp
@@ -19,6 +19,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/ADT/SmallSet.h"
+#include "smack/Debug.h"
 
 #include <deque>
 

--- a/lib/AssistDS/Devirt.cpp
+++ b/lib/AssistDS/Devirt.cpp
@@ -11,7 +11,7 @@
 
 #include "assistDS/Devirt.h"
 
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/ADT/Statistic.h"
 

--- a/lib/AssistDS/FuncSimplify.cpp
+++ b/lib/AssistDS/FuncSimplify.cpp
@@ -14,7 +14,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 
 #include <set>
 #include <map>

--- a/lib/AssistDS/FuncSpec.cpp
+++ b/lib/AssistDS/FuncSpec.cpp
@@ -18,7 +18,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 
 #include <set>
 #include <map>

--- a/lib/AssistDS/GEPExprArgs.cpp
+++ b/lib/AssistDS/GEPExprArgs.cpp
@@ -21,7 +21,7 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/ValueMap.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include <vector>
 #include <map>
 

--- a/lib/AssistDS/Int2PtrCmp.cpp
+++ b/lib/AssistDS/Int2PtrCmp.cpp
@@ -17,7 +17,7 @@
 #include "assistDS/Int2PtrCmp.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/IR/PatternMatch.h"
 
 #include <set>

--- a/lib/AssistDS/LoadArgs.cpp
+++ b/lib/AssistDS/LoadArgs.cpp
@@ -22,7 +22,7 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/ValueMap.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include <vector>
 #include <set>
 #include <map>

--- a/lib/AssistDS/MergeGEP.cpp
+++ b/lib/AssistDS/MergeGEP.cpp
@@ -22,7 +22,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 
 #include <vector>
 // Pass statistics

--- a/lib/AssistDS/SimplifyExtractValue.cpp
+++ b/lib/AssistDS/SimplifyExtractValue.cpp
@@ -19,7 +19,7 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/IR/DataLayout.h"
 

--- a/lib/AssistDS/SimplifyGEP.cpp
+++ b/lib/AssistDS/SimplifyGEP.cpp
@@ -17,7 +17,7 @@
 #include "assistDS/SimplifyGEP.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Operator.h"

--- a/lib/AssistDS/SimplifyInsertValue.cpp
+++ b/lib/AssistDS/SimplifyInsertValue.cpp
@@ -17,7 +17,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/IR/DataLayout.h"
 

--- a/lib/AssistDS/SimplifyLoad.cpp
+++ b/lib/AssistDS/SimplifyLoad.cpp
@@ -15,7 +15,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/IR/DataLayout.h"
 

--- a/lib/AssistDS/StructReturnToPointer.cpp
+++ b/lib/AssistDS/StructReturnToPointer.cpp
@@ -20,7 +20,7 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/ValueMap.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 
 #include <set>
 #include <map>
@@ -126,7 +126,7 @@ bool StructRet::runOnModule(Module& M) {
             Builder.CreateStore(CS->getAggregateElement(i),
                 Builder.CreateGEP(fargs.at(0), ArrayRef<Value*>(idxs)));
           }
-          assert(RI->getNumOperand == 1 && "Return should only have one operand");
+          assert(RI->getNumOperands() == 1 && "Return should only have one operand");
           RI->setOperand(0, UndefValue::get(ST));
         } else
           llvm_unreachable("Unexpected struct-type return value.");

--- a/lib/AssistDS/TypeChecks.cpp
+++ b/lib/AssistDS/TypeChecks.cpp
@@ -17,7 +17,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Module.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/IR/Intrinsics.h"

--- a/lib/AssistDS/TypeChecksOpt.cpp
+++ b/lib/AssistDS/TypeChecksOpt.cpp
@@ -17,7 +17,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Module.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/IR/Intrinsics.h"

--- a/lib/DSA/AddressTakenAnalysis.cpp
+++ b/lib/DSA/AddressTakenAnalysis.cpp
@@ -21,7 +21,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/IR/CallSite.h"
 
 #include <fstream>

--- a/lib/DSA/AllocatorIdentification.cpp
+++ b/lib/DSA/AllocatorIdentification.cpp
@@ -20,7 +20,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 
 #include <set>
 #include <map>

--- a/lib/DSA/BottomUpClosure.cpp
+++ b/lib/DSA/BottomUpClosure.cpp
@@ -20,7 +20,7 @@
 #include "dsa/DSGraph.h"
 #include "llvm/IR/Module.h"
 #include "llvm/ADT/Statistic.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/FormattedStream.h"
 
 using namespace llvm;

--- a/lib/DSA/CallTargets.cpp
+++ b/lib/DSA/CallTargets.cpp
@@ -24,7 +24,7 @@
 #include "dsa/DSGraph.h"
 #include "dsa/CallTargets.h"
 #include "llvm/ADT/Statistic.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/IR/Constants.h"
 #include <ostream>

--- a/lib/DSA/CompleteBottomUp.cpp
+++ b/lib/DSA/CompleteBottomUp.cpp
@@ -18,7 +18,7 @@
 #include "dsa/DSGraph.h"
 #include "llvm/IR/Module.h"
 #include "llvm/ADT/Statistic.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/FormattedStream.h"
 using namespace llvm;
 

--- a/lib/DSA/DSGraph.cpp
+++ b/lib/DSA/DSGraph.cpp
@@ -25,7 +25,7 @@
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/ADT/DepthFirstIterator.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SCCIterator.h"

--- a/lib/DSA/DataStructure.cpp
+++ b/lib/DSA/DataStructure.cpp
@@ -25,7 +25,7 @@
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/ADT/DepthFirstIterator.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SCCIterator.h"

--- a/lib/DSA/DataStructureStats.cpp
+++ b/lib/DSA/DataStructureStats.cpp
@@ -22,7 +22,7 @@
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/Pass.h"
 #include "llvm/ADT/Statistic.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/FormattedStream.h"
 
 #include <ostream>

--- a/lib/DSA/EntryPointAnalysis.cpp
+++ b/lib/DSA/EntryPointAnalysis.cpp
@@ -19,7 +19,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 
 #include <fstream>
 #include <set>

--- a/lib/DSA/EquivClassGraphs.cpp
+++ b/lib/DSA/EquivClassGraphs.cpp
@@ -21,7 +21,7 @@
 #include "llvm/Pass.h"
 #include "dsa/DSGraph.h"
 #include "llvm/IR/CallSite.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/ADT/SCCIterator.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/EquivalenceClasses.h"

--- a/lib/DSA/Local.cpp
+++ b/lib/DSA/Local.cpp
@@ -30,7 +30,7 @@
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Use.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/InstVisitor.h"

--- a/lib/DSA/StdLibPass.cpp
+++ b/lib/DSA/StdLibPass.cpp
@@ -22,7 +22,7 @@
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/Timer.h"
 #include <iostream>

--- a/lib/DSA/TopDownClosure.cpp
+++ b/lib/DSA/TopDownClosure.cpp
@@ -19,7 +19,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "dsa/DSGraph.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/ADT/Statistic.h"

--- a/lib/DSA/TypeSafety.cpp
+++ b/lib/DSA/TypeSafety.cpp
@@ -19,7 +19,7 @@
 
 #include "llvm/IR/Module.h"
 #include "llvm/IR/DerivedTypes.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/ADT/Statistic.h"

--- a/lib/smack/AddTiming.cpp
+++ b/lib/smack/AddTiming.cpp
@@ -28,7 +28,7 @@
 #include "llvm/IR/Value.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "smack/VerifierCodeMetadata.h"

--- a/lib/smack/BplFilePrinter.cpp
+++ b/lib/smack/BplFilePrinter.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the MIT License. See LICENSE for details.
 //
 #include "smack/BplFilePrinter.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/GraphWriter.h"
 #include <sstream>
 

--- a/lib/smack/BplPrinter.cpp
+++ b/lib/smack/BplPrinter.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the MIT License. See LICENSE for details.
 //
 #include "smack/BplPrinter.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/GraphWriter.h"
 #include <sstream>
 

--- a/lib/smack/CodifyStaticInits.cpp
+++ b/lib/smack/CodifyStaticInits.cpp
@@ -9,7 +9,7 @@
 #include "smack/Naming.h"
 #include "smack/SmackOptions.h"
 #include "llvm/IR/IRBuilder.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/Regex.h"
 #include "llvm/IR/DataLayout.h"

--- a/lib/smack/Debug.cpp
+++ b/lib/smack/Debug.cpp
@@ -1,0 +1,90 @@
+#include "smack/Debug.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/Signals.h"
+#include "llvm/Support/circular_raw_ostream.h"
+#include "llvm/Support/raw_ostream.h"
+
+#undef isCurrentDebugType
+#undef setCurrentDebugType
+#undef setCurrentDebugTypes
+
+using namespace llvm;
+using namespace smack;
+
+namespace smack {
+bool DebugFlag = false;
+
+static ManagedStatic<std::vector<std::string>> CurrentDebugType;
+
+bool isCurrentDebugType(const char *DebugType) {
+  if (CurrentDebugType->empty())
+    return true;
+  for (auto &d : *CurrentDebugType) {
+    if (d == DebugType)
+      return true;
+  }
+  return false;
+}
+
+void setCurrentDebugTypes(const char **Types, unsigned Count);
+
+void setCurrentDebugType(const char *Type) {
+  setCurrentDebugTypes(&Type, 1);
+}
+
+void setCurrentDebugTypes(const char **Types, unsigned Count) {
+  CurrentDebugType->clear();
+  for (size_t T = 0; T < Count; ++T)
+    CurrentDebugType->push_back(Types[T]);
+}
+}
+
+#ifndef NDEBUG
+
+static ::llvm::cl::opt<bool, true>
+Debug("debug", cl::desc("Enable debug output"), cl::Hidden,
+      cl::location(DebugFlag));
+
+namespace {
+
+struct DebugOnlyOpt {
+  void operator=(const std::string &Val) const {
+    if (Val.empty())
+      return;
+    DebugFlag = true;
+    SmallVector<StringRef,8> dbgTypes;
+    StringRef(Val).split(dbgTypes, ',', -1, false);
+    for (auto dbgType : dbgTypes)
+      CurrentDebugType->push_back(dbgType);
+  }
+};
+
+}
+
+static DebugOnlyOpt DebugOnlyOptLoc;
+
+static ::llvm::cl::opt<DebugOnlyOpt, true, cl::parser<std::string> >
+DebugOnly("debug-only", cl::desc("Enable a specific type of debug output (comma separated list of types)"),
+          cl::Hidden, cl::ZeroOrMore, cl::value_desc("debug string"),
+          cl::location(DebugOnlyOptLoc), cl::ValueRequired);
+
+raw_ostream &smack::dbgs() {
+  static struct dbgstream {
+    circular_raw_ostream strm;
+
+    dbgstream() :
+        strm(errs(), "*** Debug Log Output ***\n", 0) { }
+  } thestrm;
+
+  return thestrm.strm;
+}
+
+#else
+namespace smack {
+  raw_ostream &dbgs() {
+    return llvm::errs();
+  }
+}
+
+#endif

--- a/lib/smack/ExtractContracts.cpp
+++ b/lib/smack/ExtractContracts.cpp
@@ -7,10 +7,10 @@
 #include "smack/SmackOptions.h"
 #include "smack/Naming.h"
 #include "smack/ExtractContracts.h"
-#include "llvm/Support/Debug.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/Analysis/LoopInfo.h"
+#include "smack/Debug.h"
 
 #include <vector>
 #include <stack>

--- a/lib/smack/MemorySafetyChecker.cpp
+++ b/lib/smack/MemorySafetyChecker.cpp
@@ -8,7 +8,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Constants.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/IR/ValueSymbolTable.h"
 #include "llvm/IR/IntrinsicInst.h"
 

--- a/lib/smack/Regions.cpp
+++ b/lib/smack/Regions.cpp
@@ -4,6 +4,7 @@
 #include "smack/Regions.h"
 #include "smack/SmackOptions.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
+#include "smack/Debug.h"
 
 #define DEBUG_TYPE "regions"
 

--- a/lib/smack/RemoveDeadDefs.cpp
+++ b/lib/smack/RemoveDeadDefs.cpp
@@ -6,7 +6,7 @@
 
 #include "smack/SmackOptions.h"
 #include "smack/RemoveDeadDefs.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/IR/DataLayout.h"
 

--- a/lib/smack/SignedIntegerOverflowChecker.cpp
+++ b/lib/smack/SignedIntegerOverflowChecker.cpp
@@ -7,7 +7,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Constants.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/IR/ValueSymbolTable.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Support/Regex.h"

--- a/lib/smack/SimplifyLibCalls.cpp
+++ b/lib/smack/SimplifyLibCalls.cpp
@@ -7,7 +7,7 @@
 #include "smack/SmackOptions.h"
 #include "smack/Naming.h"
 #include "smack/SimplifyLibCalls.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 

--- a/lib/smack/Slicing.cpp
+++ b/lib/smack/Slicing.cpp
@@ -7,7 +7,7 @@
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Analysis/CFG.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include <vector>
 #include <queue>
 #include <set>

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -7,7 +7,7 @@
 #include "smack/Naming.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/DebugInfo.h"
-#include "llvm/Support/Debug.h"
+#include "smack/Debug.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/Support/GraphWriter.h"
 #include "llvm/Analysis/LoopInfo.h"

--- a/lib/smack/VerifierCodeMetadata.cpp
+++ b/lib/smack/VerifierCodeMetadata.cpp
@@ -6,8 +6,8 @@
 
 #include "smack/SmackOptions.h"
 #include "smack/VerifierCodeMetadata.h"
-#include "llvm/Support/Debug.h"
 #include "llvm/IR/DataLayout.h"
+#include "smack/Debug.h"
 
 #include <set>
 

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -93,6 +93,9 @@ def arguments():
   noise_group.add_argument('-d', '--debug', action="store_true", default=False,
     help='enable debugging output')
 
+  noise_group.add_argument('--debug-only', metavar='MODULES', default=None,
+    type=str, help='limit debugging output to given MODULES')
+
   parser.add_argument('-t', '--no-verify', action="store_true", default=False,
     help='perform only translation, without verification.')
 
@@ -374,6 +377,7 @@ def llvm_to_bpl(args):
   for ep in args.entry_points:
     cmd += ['-entry-points', ep]
   if args.debug: cmd += ['-debug']
+  if args.debug_only: cmd += ['-debug-only', args.debug_only]
   if args.ll_file: cmd += ['-ll', args.ll_file]
   if "impls" in args.mem_mod:cmd += ['-mem-mod-impls']
   if args.static_unroll: cmd += ['-static-unroll']


### PR DESCRIPTION
* Allow debugging build independently of how LLVM was built.
* Allow assertions to actually be checked.
* Adds `-debug` and `-debug-only` flags.
* Fixes #254.