### PR TITLE
Limit SVCOMP compiler hacks to SVCOMP frontend.

### DIFF
--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -13,6 +13,7 @@
 extern "C" {
 #endif
 
+#ifdef SVCOMP
 // Apprently needed by SVCOMP benchmarks
 #define __inline
 #define __builtin_expect __builtinx_expect
@@ -22,6 +23,7 @@ extern "C" {
 
 // For handling of va_start macro
 void __builtinx_va_start(char*,char*);
+#endif
 
 void __SMACK_code(const char *fmt, ...);
 void __SMACK_mod(const char *fmt, ...);

--- a/share/smack/svcomp/utils.py
+++ b/share/smack/svcomp/utils.py
@@ -49,6 +49,7 @@ def svcomp_frontend(args):
   name, ext = os.path.splitext(os.path.basename(args.input_files[0]))
   svcomp_process_file(args, name, ext)
 
+  args.clang_options += " -DSVCOMP"
   args.clang_options += " -DAVOID_NAME_CONFLICTS"
   args.clang_options += " -DCUSTOM_VERIFIER_ASSERT"
   args.clang_options += " -DNO_FORALL"


### PR DESCRIPTION
* Avoid platform-specific `__builtin_*` macros.
* Defining `__builtin_memcpy` as `__builtinx_memcpy` confuses Clang on OSX.
* Fixes #239.