### PR TITLE
Add support for one bit integers for languages that use this type

### DIFF
--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -42,7 +42,7 @@ smack_value_t __SMACK_return_value(void);
 // Inserts memory access checks in form of assert to check null pointer access
 // and buffer overflow errors
 void __SMACK_check_memory_safety(void*, unsigned long);
-void __SMACK_check_memory_leak();
+void __SMACK_check_memory_leak(void);
 #endif
 
 // We need this to enforce that assert/assume are function calls
@@ -154,7 +154,7 @@ unsigned long __VERIFIER_nondet_ulong(void);
 void* __VERIFIER_nondet_pointer(void);
 
 
-void __SMACK_decls();
+void __SMACK_decls(void);
 
 #ifdef __cplusplus
 }

--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -145,7 +145,7 @@ NONDET_DECL(__VERIFIER_nondet,long,double);
 #undef U
 #undef NONDET_DECL
 
-// Apparently used in SVCOMP benchmarks
+// Used in SVCOMP benchmarks
 _Bool __VERIFIER_nondet_bool(void);
 unsigned char __VERIFIER_nondet_uchar(void);
 unsigned short __VERIFIER_nondet_ushort(void);

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -212,7 +212,7 @@ unsigned long long int __VERIFIER_nondet_unsigned_long_long_int() {
   return x;
 }
 
-// Apparently used in SVCCOMP benchmarks
+// Used in SVCCOMP benchmarks
 _Bool __VERIFIER_nondet_bool(void) {
   _Bool x = (_Bool)__VERIFIER_nondet_int();
   __VERIFIER_assume(x == 0 || x == 1);

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -68,145 +68,145 @@ void exit(int x) {
   while(1);
 }
 
-char __VERIFIER_nondet_char() {
+char __VERIFIER_nondet_char(void) {
   char x = __SMACK_nondet_char();
   __VERIFIER_assume(x >= SCHAR_MIN && x <= SCHAR_MAX);
   return x;
 }
 
-signed char __VERIFIER_nondet_signed_char() {
+signed char __VERIFIER_nondet_signed_char(void) {
   signed char x = __SMACK_nondet_signed_char();
   __VERIFIER_assume(x >= SCHAR_MIN && x <= SCHAR_MAX);
   return x;
 }
 
-unsigned char __VERIFIER_nondet_unsigned_char() {
+unsigned char __VERIFIER_nondet_unsigned_char(void) {
   unsigned char x = __SMACK_nondet_unsigned_char();
   __VERIFIER_assume(x >= 0 && x <= UCHAR_MAX);
   return x;
 }
 
-short __VERIFIER_nondet_short() {
+short __VERIFIER_nondet_short(void) {
   short x = __SMACK_nondet_short();
   __VERIFIER_assume(x >= SHRT_MIN && x <= SHRT_MAX);
   return x;
 }
 
-signed short __VERIFIER_nondet_signed_short() {
+signed short __VERIFIER_nondet_signed_short(void) {
   signed short x = __SMACK_nondet_signed_short();
   __VERIFIER_assume(x >= SHRT_MIN && x <= SHRT_MAX);
   return x;
 }
 
-signed short int __VERIFIER_nondet_signed_short_int() {
+signed short int __VERIFIER_nondet_signed_short_int(void) {
   signed short int x = __SMACK_nondet_signed_short_int();
   __VERIFIER_assume(x >= SHRT_MIN && x <= SHRT_MAX);
   return x;
 }
 
-unsigned short __VERIFIER_nondet_unsigned_short() {
+unsigned short __VERIFIER_nondet_unsigned_short(void) {
   unsigned short x = __SMACK_nondet_unsigned_short();
   __VERIFIER_assume(x >= 0 && x <= USHRT_MAX);
   return x;
 }
 
-unsigned short int __VERIFIER_nondet_unsigned_short_int() {
+unsigned short int __VERIFIER_nondet_unsigned_short_int(void) {
   unsigned short int x = __SMACK_nondet_unsigned_short_int();
   __VERIFIER_assume(x >= 0 && x <= USHRT_MAX);
   return x;
 }
 
-int __VERIFIER_nondet_int() {
+int __VERIFIER_nondet_int(void) {
   int x = __SMACK_nondet_int();
   __VERIFIER_assume(x >= INT_MIN && x <= INT_MAX);
   return x;
 }
 
-signed int __VERIFIER_nondet_signed_int() {
+signed int __VERIFIER_nondet_signed_int(void) {
   signed int x = __SMACK_nondet_signed_int();
   __VERIFIER_assume(x >= INT_MIN && x <= INT_MAX);
   return x;
 }
 
-unsigned __VERIFIER_nondet_unsigned() {
+unsigned __VERIFIER_nondet_unsigned(void) {
   unsigned x = __SMACK_nondet_unsigned();
   __VERIFIER_assume(x >= 0 && x <= UINT_MAX);
   return x;
 }
 
-unsigned int __VERIFIER_nondet_unsigned_int() {
+unsigned int __VERIFIER_nondet_unsigned_int(void) {
   unsigned int x = __SMACK_nondet_unsigned_int();
   __VERIFIER_assume(x >= 0 && x <= UINT_MAX);
   return x;
 }
 
-long __VERIFIER_nondet_long() {
+long __VERIFIER_nondet_long(void) {
   long x = __SMACK_nondet_long();
   __VERIFIER_assume(x >= LONG_MIN && x <= LONG_MAX);
   return x;
 }
 
-long int __VERIFIER_nondet_long_int() {
+long int __VERIFIER_nondet_long_int(void) {
   long int x = __SMACK_nondet_long_int();
   __VERIFIER_assume(x >= LONG_MIN && x <= LONG_MAX);
   return x;
 }
 
-signed long __VERIFIER_nondet_signed_long() {
+signed long __VERIFIER_nondet_signed_long(void) {
   signed long x = __SMACK_nondet_signed_long();
   __VERIFIER_assume(x >= LONG_MIN && x <= LONG_MAX);
   return x;
 }
 
-signed long int __VERIFIER_nondet_signed_long_int() {
+signed long int __VERIFIER_nondet_signed_long_int(void) {
   signed long int x = __SMACK_nondet_signed_long_int();
   __VERIFIER_assume(x >= LONG_MIN && x <= LONG_MAX);
   return x;
 }
 
-unsigned long __VERIFIER_nondet_unsigned_long() {
+unsigned long __VERIFIER_nondet_unsigned_long(void) {
   unsigned long x = __SMACK_nondet_unsigned_long();
   __VERIFIER_assume(x >= 0 && x <= ULONG_MAX);
   return x;
 }
 
-unsigned long int __VERIFIER_nondet_unsigned_long_int() {
+unsigned long int __VERIFIER_nondet_unsigned_long_int(void) {
   unsigned long int x = __SMACK_nondet_unsigned_long_int();
   __VERIFIER_assume(x >= 0 && x <= ULONG_MAX);
   return x;
 }
 
-long long __VERIFIER_nondet_long_long() {
+long long __VERIFIER_nondet_long_long(void) {
   long long x = __SMACK_nondet_long_long();
   __VERIFIER_assume(x >= LLONG_MIN && x <= LLONG_MAX);
   return x;
 }
 
-long long int __VERIFIER_nondet_long_long_int() {
+long long int __VERIFIER_nondet_long_long_int(void) {
   long long int x = __SMACK_nondet_long_long_int();
   __VERIFIER_assume(x >= LLONG_MIN && x <= LLONG_MAX);
   return x;
 }
 
-signed long long __VERIFIER_nondet_signed_long_long() {
+signed long long __VERIFIER_nondet_signed_long_long(void) {
   signed long long x = __SMACK_nondet_signed_long_long();
   __VERIFIER_assume(x >= LLONG_MIN && x <= LLONG_MAX);
   return x;
 }
 
-signed long long int __VERIFIER_nondet_signed_long_long_int() {
+signed long long int __VERIFIER_nondet_signed_long_long_int(void) {
   signed long long int x = __SMACK_nondet_signed_long_long_int();
   __VERIFIER_assume(x >= LLONG_MIN && x <= LLONG_MAX);
   return x;
 }
 
-unsigned long long __VERIFIER_nondet_unsigned_long_long() {
+unsigned long long __VERIFIER_nondet_unsigned_long_long(void) {
   unsigned long long x = __SMACK_nondet_unsigned_long_long();
   __VERIFIER_assume(x >= 0 && x <= ULLONG_MAX);
   return x;
 }
 
-unsigned long long int __VERIFIER_nondet_unsigned_long_long_int() {
+unsigned long long int __VERIFIER_nondet_unsigned_long_long_int(void) {
   unsigned long long int x = __SMACK_nondet_unsigned_long_long_int();
   __VERIFIER_assume(x >= 0 && x <= ULLONG_MAX);
   return x;
@@ -381,7 +381,7 @@ void __SMACK_dummy(int v) {
   D(xstr(M(bvdouble,args))); \
   D(xstr(M(bvlongdouble,args)));
 
-void __SMACK_decls() {
+void __SMACK_decls(void) {
 
   DECLARE(INLINE_CONVERSION,ref,ref,$bitcast,{i});
 
@@ -1772,7 +1772,7 @@ void __SMACK_check_memory_safety(void* pointer, unsigned long size) {
 #endif
 }
 
-void __SMACK_check_memory_leak() {
+void __SMACK_check_memory_leak(void) {
   __SMACK_code("assert {:valid_memtrack} $allocatedCounter == 0;");
 }
 #endif

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -1394,6 +1394,7 @@ void __SMACK_decls(void) {
   D("function {:inline} $load.i24(M: [ref] i24, p: ref) returns (i24) { M[p] }");
   D("function {:inline} $load.i16(M: [ref] i16, p: ref) returns (i16) { M[p] }");
   D("function {:inline} $load.i8(M: [ref] i8, p: ref) returns (i8) { M[p] }");
+  D("function {:inline} $load.i1(M: [ref] i1, p: ref) returns (i1) { M[p] }");
 
   D("function {:inline} $load.bv128(M: [ref] bv128, p: ref) returns (bv128) { M[p] }");
   D("function {:inline} $load.bv96(M: [ref] bv96, p: ref) returns (bv96) { M[p] }");
@@ -1428,7 +1429,8 @@ void __SMACK_decls(void) {
   D("function {:inline} $load.bytes.bv16(M: [ref] bv8, p: ref) returns (bv16)"
     "{ M[$add.ref(p, $1.ref)] ++ M[p] }");
   D("function {:inline} $load.bytes.bv8(M: [ref] bv8, p: ref) returns (bv8) { M[p] }");
-
+  D("function {:inline} $load.bytes.bv1(M: [ref] bv8, p: ref) returns (bv1) { $trunc.bv8.bv1(M[p]) }");
+  
   D("function {:inline} $store.i128(M: [ref] i128, p: ref, v: i128) returns ([ref] i128) { M[p := v] }");
   D("function {:inline} $store.i96(M: [ref] i96, p: ref, v: i96) returns ([ref] i96) { M[p := v] }");
   D("function {:inline} $store.i88(M: [ref] i88, p: ref, v: i88) returns ([ref] i88) { M[p := v] }");
@@ -1440,6 +1442,7 @@ void __SMACK_decls(void) {
   D("function {:inline} $store.i24(M: [ref] i24, p: ref, v: i24) returns ([ref] i24) { M[p := v] }");
   D("function {:inline} $store.i16(M: [ref] i16, p: ref, v: i16) returns ([ref] i16) { M[p := v] }");
   D("function {:inline} $store.i8(M: [ref] i8, p: ref, v: i8) returns ([ref] i8) { M[p := v] }");
+  D("function {:inline} $store.i1(M: [ref] i1, p: ref, v: i1) returns ([ref] i1) { M[p := v] }");
 
   D("function {:inline} $store.bv128(M: [ref] bv128, p: ref, v: bv128) returns ([ref] bv128) { M[p := v] }");
   D("function {:inline} $store.bv96(M: [ref] bv96, p: ref, v: bv96) returns ([ref] bv96) { M[p := v] }");
@@ -1503,7 +1506,8 @@ void __SMACK_decls(void) {
   D("function {:inline} $store.bytes.bv16(M:[ref]bv8, p:ref, v:bv16) returns ([ref]bv8) {"
     "M[p := v[8:0]][$add.ref(p, $1.ref) := v[16:8]]}");
   D("function {:inline} $store.bytes.bv8(M:[ref]bv8, p:ref, v:bv8) returns ([ref]bv8) {M[p := v]}");
-
+  D("function {:inline} $store.bytes.bv1(M:[ref]bv8, p:ref, v:bv1) returns ([ref]bv8) {M[p := $zext.bv1.bv8(v)]}");
+  
   D("function {:inline} $load.ref(M: [ref] ref, p: ref) returns (ref) { M[p] }");
   D("function {:inline} $store.ref(M: [ref] ref, p: ref, v: ref) returns ([ref] ref) { M[p := v] }");
 

--- a/test/basic/limits.c
+++ b/test/basic/limits.c
@@ -1,0 +1,97 @@
+#include <limits.h>
+#include "smack.h"
+
+// @expect verified
+
+int main(void) {
+  char x1 = __VERIFIER_nondet_char();
+  assert(x1 >= SCHAR_MIN && x1 <= SCHAR_MAX);
+
+  signed char x2 = __VERIFIER_nondet_signed_char();
+  assert(x2 >= SCHAR_MIN && x2 <= SCHAR_MAX);
+
+  unsigned char x3 = __VERIFIER_nondet_unsigned_char();
+  assert(x3 >= 0 && x3 <= UCHAR_MAX);
+
+  short x4 = __VERIFIER_nondet_short();
+  assert(x4 >= SHRT_MIN && x4 <= SHRT_MAX);
+
+  signed short x5 = __VERIFIER_nondet_signed_short();
+  assert(x5 >= SHRT_MIN && x5 <= SHRT_MAX);
+
+  signed short int x6 = __VERIFIER_nondet_signed_short_int();
+  assert(x6 >= SHRT_MIN && x6 <= SHRT_MAX);
+
+  unsigned short x7 = __VERIFIER_nondet_unsigned_short();
+  assert(x7 >= 0 && x7 <= USHRT_MAX);
+
+  unsigned short int x8 = __VERIFIER_nondet_unsigned_short_int();
+  assert(x8 >= 0 && x8 <= USHRT_MAX);
+
+  int x9 = __VERIFIER_nondet_int();
+  assert(x9 >= INT_MIN && x9 <= INT_MAX);
+
+  signed int x10 = __VERIFIER_nondet_signed_int();
+  assert(x10 >= INT_MIN && x10 <= INT_MAX);
+
+  unsigned x11 = __VERIFIER_nondet_unsigned();
+  assert(x11 >= 0 && x11 <= UINT_MAX);
+
+  unsigned int x12 = __VERIFIER_nondet_unsigned_int();
+  assert(x12 >= 0 && x12 <= UINT_MAX);
+
+  long x13 = __VERIFIER_nondet_long();
+  assert(x13 >= LONG_MIN && x13 <= LONG_MAX);
+
+  long int x14 = __VERIFIER_nondet_long_int();
+  assert(x14 >= LONG_MIN && x14 <= LONG_MAX);
+
+  signed long x15 = __VERIFIER_nondet_signed_long();
+  assert(x15 >= LONG_MIN && x15 <= LONG_MAX);
+
+  signed long int x16 = __VERIFIER_nondet_signed_long_int();
+  assert(x16 >= LONG_MIN && x16 <= LONG_MAX);
+
+  unsigned long x17 = __VERIFIER_nondet_unsigned_long();
+  assert(x17 >= 0 && x17 <= ULONG_MAX);
+
+  unsigned long int x18 = __VERIFIER_nondet_unsigned_long_int();
+  assert(x18 >= 0 && x18 <= ULONG_MAX);
+
+  long long x19 = __VERIFIER_nondet_long_long();
+  assert(x19 >= LLONG_MIN && x19 <= LLONG_MAX);
+
+  long long int x20 = __VERIFIER_nondet_long_long_int();
+  assert(x20 >= LLONG_MIN && x20 <= LLONG_MAX);
+
+  signed long long x21 = __VERIFIER_nondet_signed_long_long();
+  assert(x21 >= LLONG_MIN && x21 <= LLONG_MAX);
+
+  signed long long int x22 = __VERIFIER_nondet_signed_long_long_int();
+  assert(x22 >= LLONG_MIN && x22 <= LLONG_MAX);
+
+  unsigned long long x23 = __VERIFIER_nondet_unsigned_long_long();
+  assert(x23 >= 0 && x23 <= ULLONG_MAX);
+
+  unsigned long long int x24 = __VERIFIER_nondet_unsigned_long_long_int();
+  assert(x24 >= 0 && x24 <= ULLONG_MAX);
+
+// Used in SVCCOMP benchmarks
+  _Bool x25 = __VERIFIER_nondet_bool();
+  assert(x25 == 0 || x25 == 1);
+
+  unsigned char x26 = __VERIFIER_nondet_uchar();
+  assert(x26 >= 0 && x26 <= UCHAR_MAX);
+
+  unsigned short x27 = __VERIFIER_nondet_ushort();
+  assert(x27 >= 0 && x27 <= USHRT_MAX);
+
+  unsigned int x28 = __VERIFIER_nondet_uint();
+  assert(x28 >= 0 && x28 <= UINT_MAX);
+
+  unsigned long x29 = __VERIFIER_nondet_ulong();
+  assert(x29 >= 0 && x29 <= ULONG_MAX);
+
+  return 0;
+}
+

--- a/test/basic/limits_fail.c
+++ b/test/basic/limits_fail.c
@@ -1,0 +1,97 @@
+#include <limits.h>
+#include "smack.h"
+
+// @expect error
+
+int main(void) {
+  char x1 = __VERIFIER_nondet_char();
+  assert(x1 >= SCHAR_MIN && x1 <= SCHAR_MAX);
+
+  signed char x2 = __VERIFIER_nondet_signed_char();
+  assert(x2 >= SCHAR_MIN && x2 <= SCHAR_MAX);
+
+  unsigned char x3 = __VERIFIER_nondet_unsigned_char();
+  assert(x3 >= 0 && x3 <= UCHAR_MAX);
+
+  short x4 = __VERIFIER_nondet_short();
+  assert(x4 >= SHRT_MIN && x4 <= SHRT_MAX);
+
+  signed short x5 = __VERIFIER_nondet_signed_short();
+  assert(x5 >= SHRT_MIN && x5 <= SHRT_MAX);
+
+  signed short int x6 = __VERIFIER_nondet_signed_short_int();
+  assert(x6 >= SHRT_MIN && x6 <= SHRT_MAX);
+
+  unsigned short x7 = __VERIFIER_nondet_unsigned_short();
+  assert(x7 >= 0 && x7 <= USHRT_MAX);
+
+  unsigned short int x8 = __VERIFIER_nondet_unsigned_short_int();
+  assert(x8 >= 0 && x8 <= USHRT_MAX);
+
+  int x9 = __VERIFIER_nondet_int();
+  assert(x9 >= INT_MIN && x9 <= INT_MAX);
+
+  signed int x10 = __VERIFIER_nondet_signed_int();
+  assert(x10 >= INT_MIN && x10 <= INT_MAX);
+
+  unsigned x11 = __VERIFIER_nondet_unsigned();
+  assert(x11 >= 0 && x11 <= UINT_MAX);
+
+  unsigned int x12 = __VERIFIER_nondet_unsigned_int();
+  assert(x12 >= 0 && x12 <= UINT_MAX);
+
+  long x13 = __VERIFIER_nondet_long();
+  assert(x13 >= LONG_MIN && x13 <= LONG_MAX);
+
+  long int x14 = __VERIFIER_nondet_long_int();
+  assert(x14 >= LONG_MIN && x14 <= LONG_MAX);
+
+  signed long x15 = __VERIFIER_nondet_signed_long();
+  assert(x15 >= LONG_MIN && x15 <= LONG_MAX);
+
+  signed long int x16 = __VERIFIER_nondet_signed_long_int();
+  assert(x16 >= LONG_MIN && x16 <= LONG_MAX);
+
+  unsigned long x17 = __VERIFIER_nondet_unsigned_long();
+  assert(x17 >= 0 && x17 <= ULONG_MAX);
+
+  unsigned long int x18 = __VERIFIER_nondet_unsigned_long_int();
+  assert(x18 >= 0 && x18 <= ULONG_MAX);
+
+  long long x19 = __VERIFIER_nondet_long_long();
+  assert(x19 >= LLONG_MIN && x19 <= LLONG_MAX);
+
+  long long int x20 = __VERIFIER_nondet_long_long_int();
+  assert(x20 >= LLONG_MIN && x20 <= LLONG_MAX);
+
+  signed long long x21 = __VERIFIER_nondet_signed_long_long();
+  assert(x21 >= LLONG_MIN && x21 <= LLONG_MAX);
+
+  signed long long int x22 = __VERIFIER_nondet_signed_long_long_int();
+  assert(x22 >= LLONG_MIN && x22 <= LLONG_MAX);
+
+  unsigned long long x23 = __VERIFIER_nondet_unsigned_long_long();
+  assert(x23 >= 0 && x23 <= ULLONG_MAX);
+
+  unsigned long long int x24 = __VERIFIER_nondet_unsigned_long_long_int();
+  assert(x24 >= 0 && x24 <= ULLONG_MAX);
+
+// Used in SVCCOMP benchmarks
+  _Bool x25 = __VERIFIER_nondet_bool();
+  assert(x25 == 0 || x25 == 1);
+
+  unsigned char x26 = __VERIFIER_nondet_uchar();
+  assert(x26 >= 0 && x26 <= UCHAR_MAX);
+
+  unsigned short x27 = __VERIFIER_nondet_ushort();
+  assert(x27 >= 0 && x27 <= USHRT_MAX);
+
+  unsigned int x28 = __VERIFIER_nondet_uint();
+  assert(x28 >= 0 && x28 <= UINT_MAX);
+
+  unsigned long x29 = __VERIFIER_nondet_ulong();
+  assert(x29 >= 1 && x29 <= ULONG_MAX);
+
+  return 0;
+}
+


### PR DESCRIPTION
Adds support for the 1-bit integer type for regular integers, and sign extension/truncation for 1-bit bit-vectors. The Rust compiler emits this type for the boolean type. Other languages may require this feature as well.