### PR TITLE
Add support i1 and bv1 for languages that use these types

### DIFF
--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -1407,6 +1407,7 @@ void __SMACK_decls(void) {
   D("function {:inline} $load.bv24(M: [ref] bv24, p: ref) returns (bv24) { M[p] }");
   D("function {:inline} $load.bv16(M: [ref] bv16, p: ref) returns (bv16) { M[p] }");
   D("function {:inline} $load.bv8(M: [ref] bv8, p: ref) returns (bv8) { M[p] }");
+  D("function {:inline} $load.bv1(M: [ref] bv1, p: ref) returns (bv1) { M[p] }");
 
   D("function {:inline} $load.bytes.bv128(M: [ref] bv8, p: ref) returns (bv128)"
     "{ $load.bytes.bv64(M, $add.ref(p, $8.ref)) ++ $load.bytes.bv64(M, p) }");
@@ -1455,6 +1456,7 @@ void __SMACK_decls(void) {
   D("function {:inline} $store.bv24(M: [ref] bv24, p: ref, v: bv24) returns ([ref] bv24) { M[p := v] }");
   D("function {:inline} $store.bv16(M: [ref] bv16, p: ref, v: bv16) returns ([ref] bv16) { M[p := v] }");
   D("function {:inline} $store.bv8(M: [ref] bv8, p: ref, v: bv8) returns ([ref] bv8) { M[p := v] }");
+  D("function {:inline} $store.bv1(M: [ref] bv1, p: ref, v: bv1) returns ([ref] bv1) { M[p := v] }");
 
   D("function {:inline} $store.bytes.bv128(M:[ref]bv8, p:ref, v:bv128) returns ([ref]bv8){"
     "M[p := v[8:0]][$add.ref(p, $1.ref) := v[16:8]]"

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -1394,6 +1394,7 @@ void __SMACK_decls(void) {
   D("function {:inline} $load.i24(M: [ref] i24, p: ref) returns (i24) { M[p] }");
   D("function {:inline} $load.i16(M: [ref] i16, p: ref) returns (i16) { M[p] }");
   D("function {:inline} $load.i8(M: [ref] i8, p: ref) returns (i8) { M[p] }");
+  D("function {:inline} $load.i1(M: [ref] i1, p: ref) returns (i1) { M[p] }");
 
   D("function {:inline} $load.bv128(M: [ref] bv128, p: ref) returns (bv128) { M[p] }");
   D("function {:inline} $load.bv96(M: [ref] bv96, p: ref) returns (bv96) { M[p] }");
@@ -1428,7 +1429,8 @@ void __SMACK_decls(void) {
   D("function {:inline} $load.bytes.bv16(M: [ref] bv8, p: ref) returns (bv16)"
     "{ M[$add.ref(p, $1.ref)] ++ M[p] }");
   D("function {:inline} $load.bytes.bv8(M: [ref] bv8, p: ref) returns (bv8) { M[p] }");
-
+  D("function {:inline} $load.bytes.bv1(M: [ref] bv8, p: ref) returns (bv1) { $trunc.bv8.bv1(M[p]) }");
+  
   D("function {:inline} $store.i128(M: [ref] i128, p: ref, v: i128) returns ([ref] i128) { M[p := v] }");
   D("function {:inline} $store.i96(M: [ref] i96, p: ref, v: i96) returns ([ref] i96) { M[p := v] }");
   D("function {:inline} $store.i88(M: [ref] i88, p: ref, v: i88) returns ([ref] i88) { M[p := v] }");
@@ -1440,6 +1442,7 @@ void __SMACK_decls(void) {
   D("function {:inline} $store.i24(M: [ref] i24, p: ref, v: i24) returns ([ref] i24) { M[p := v] }");
   D("function {:inline} $store.i16(M: [ref] i16, p: ref, v: i16) returns ([ref] i16) { M[p := v] }");
   D("function {:inline} $store.i8(M: [ref] i8, p: ref, v: i8) returns ([ref] i8) { M[p := v] }");
+  D("function {:inline} $store.i1(M: [ref] i1, p: ref, v: i1) returns ([ref] i1) { M[p := v] }");
 
   D("function {:inline} $store.bv128(M: [ref] bv128, p: ref, v: bv128) returns ([ref] bv128) { M[p := v] }");
   D("function {:inline} $store.bv96(M: [ref] bv96, p: ref, v: bv96) returns ([ref] bv96) { M[p := v] }");
@@ -1503,7 +1506,8 @@ void __SMACK_decls(void) {
   D("function {:inline} $store.bytes.bv16(M:[ref]bv8, p:ref, v:bv16) returns ([ref]bv8) {"
     "M[p := v[8:0]][$add.ref(p, $1.ref) := v[16:8]]}");
   D("function {:inline} $store.bytes.bv8(M:[ref]bv8, p:ref, v:bv8) returns ([ref]bv8) {M[p := v]}");
-
+  D("function {:inline} $store.bytes.bv1(M:[ref]bv8, p:ref, v:bv1) returns ([ref]bv8) {M[p := $zext.bv1.bv8(v)]}");
+  
   D("function {:inline} $load.ref(M: [ref] ref, p: ref) returns (ref) { M[p] }");
   D("function {:inline} $store.ref(M: [ref] ref, p: ref, v: ref) returns ([ref] ref) { M[p := v] }");
 


### PR DESCRIPTION
Adds support for the 1-bit integer type for regular integers, and sign extension/truncation for 1-bit bit-vectors. The Rust compiler emits i1 and bv1 (in bv mode) for the boolean type. Other languages may require this feature as well.