### PR TITLE
Rewrite select instruction encoding

### DIFF
--- a/include/smack/BoogieAst.h
+++ b/include/smack/BoogieAst.h
@@ -38,6 +38,7 @@ public:
   static const Expr* not_(const Expr* e);
   static const Expr* sel(const Expr* b, const Expr* i);
   static const Expr* sel(std::string b, std::string i);
+  static const Expr* if_then_else(const Expr* c, const Expr* t, const Expr* e);
 };
 
 class BinExpr : public Expr {
@@ -179,6 +180,16 @@ class VarExpr : public Expr {
 public:
   VarExpr(std::string v) : var(v) {}
   std::string name() const { return var; }
+  void print(std::ostream& os) const;
+};
+
+class IfThenElseExpr : public Expr {
+  const Expr* cond;
+  const Expr* true_value;
+  const Expr* false_value;
+public:
+  IfThenElseExpr(const Expr* c, const Expr* t, const Expr* e)
+    : cond(c), true_value(t), false_value(e) {}
   void print(std::ostream& os) const;
 };
 

--- a/lib/smack/BoogieAst.cpp
+++ b/lib/smack/BoogieAst.cpp
@@ -115,6 +115,10 @@ const Expr* Expr::sel(std::string b, std::string i) {
   return new SelExpr(id(b), id(i));
 }
 
+const Expr* Expr::if_then_else(const Expr* c, const Expr* t, const Expr* e) {
+  return new IfThenElseExpr(c, t, e);
+}
+
 const Attr* Attr::attr(std::string s, std::initializer_list<const Expr*> vs) {
   return new Attr(s,vs);
 }
@@ -470,6 +474,10 @@ void CodeExpr::print(std::ostream& os) const {
     print_seq<Decl*>(os, decls, "  ", "\n  ", "\n");
   print_seq<Block*>(os, blocks, "\n");
   os << "\n" << "}|";
+}
+
+void IfThenElseExpr::print(std::ostream& os) const {
+  os << "if " << cond << " then " << true_value << " else " << false_value;
 }
 
 void StringLit::print(std::ostream& os) const {

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -490,15 +490,13 @@ void SmackInstGenerator::visitSelectInst(llvm::SelectInst& i) {
   processInstruction(i);
   std::string x = naming->get(i);
   const Expr
-  *c = rep->expr(i.getOperand(0)),
-   *v1 = rep->expr(i.getOperand(1)),
-    *v2 = rep->expr(i.getOperand(2));
+  *c = rep->expr(i.getCondition()),
+   *v1 = rep->expr(i.getTrueValue()),
+    *v2 = rep->expr(i.getFalseValue());
 
-  emit(Stmt::havoc(x));
-  emit(Stmt::assume(Expr::and_(
-    Expr::impl(Expr::eq(c,rep->integerLit(1L,1)), Expr::eq(Expr::id(x), v1)),
-    Expr::impl(Expr::neq(c,rep->integerLit(1L,1)), Expr::eq(Expr::id(x), v2))
-  )));
+  assert(!i.getCondition()->getType()->isVectorTy() && "Vector condition is not supported.");
+  emit(Stmt::assign(Expr::id(x),
+    Expr::if_then_else(Expr::eq(c, rep->integerLit(1L,1)), v1, v2)));
 }
 
 void SmackInstGenerator::visitCallInst(llvm::CallInst& ci) {

--- a/test/basic/select.c
+++ b/test/basic/select.c
@@ -1,0 +1,9 @@
+#include "smack.h"
+
+// @expect verified
+// @checkbpl grep -P ":= if.+then.+else.+"
+
+int main(void) {
+  int c = 2;
+  assert(c == 2 ? 1 : 0);
+}

--- a/test/basic/select_fail.c
+++ b/test/basic/select_fail.c
@@ -1,0 +1,9 @@
+#include "smack.h"
+
+// @expect error
+// @checkbpl grep -P ":= if.+then.+else.+"
+
+int main(void) {
+  int c = 2;
+  assert(c != 2 ? 1 : 0);
+}


### PR DESCRIPTION
The old encoding translates a select instruction to `havoc(x); assume(c==1==>x==v1 && c!=1==>x==v2);` where `c` is the condition and `v1`, `v2` is true value and false value, respectively.

The new encoding translates it to `x = if c ==1 then v1 else v2`.

This pull request addresses issue #174.