### PR TITLE
Add support for recording function argument values

### DIFF
--- a/include/smack/SmackInstGenerator.h
+++ b/include/smack/SmackInstGenerator.h
@@ -30,7 +30,6 @@ private:
 
   Block* currBlock;
   llvm::BasicBlock::const_iterator nextInst;
-  llvm::Instruction* firstNonDebugInst;
   std::map<const llvm::BasicBlock*, Block*> blockMap;
   std::map<const llvm::Value*, std::string> sourceNames;
 
@@ -51,7 +50,7 @@ public:
 
 public:
   SmackInstGenerator(llvm::LoopInfo& LI, SmackRep* R, ProcDecl* P, Naming* N)
-    : loops(LI), rep(R), proc(P), naming(N), firstNonDebugInst(nullptr) {}
+    : loops(LI), rep(R), proc(P), naming(N) {}
 
 
   void visitBasicBlock(llvm::BasicBlock& bb);

--- a/include/smack/SmackInstGenerator.h
+++ b/include/smack/SmackInstGenerator.h
@@ -30,7 +30,7 @@ private:
 
   Block* currBlock;
   llvm::BasicBlock::const_iterator nextInst;
-  llvm::Instruction* fstNonDebugInst;
+  llvm::Instruction* firstNonDebugInst;
   std::map<const llvm::BasicBlock*, Block*> blockMap;
   std::map<const llvm::Value*, std::string> sourceNames;
 
@@ -51,7 +51,7 @@ public:
 
 public:
   SmackInstGenerator(llvm::LoopInfo& LI, SmackRep* R, ProcDecl* P, Naming* N)
-    : loops(LI), rep(R), proc(P), naming(N) {}
+    : loops(LI), rep(R), proc(P), naming(N), firstNonDebugInst(nullptr) {}
 
 
   void visitBasicBlock(llvm::BasicBlock& bb);

--- a/include/smack/SmackInstGenerator.h
+++ b/include/smack/SmackInstGenerator.h
@@ -30,6 +30,7 @@ private:
 
   Block* currBlock;
   llvm::BasicBlock::const_iterator nextInst;
+  llvm::Instruction* fstNonDebugInst;
   std::map<const llvm::BasicBlock*, Block*> blockMap;
   std::map<const llvm::Value*, std::string> sourceNames;
 

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -147,11 +147,11 @@ void SmackInstGenerator::visitBasicBlock(llvm::BasicBlock& bb) {
         break;
       }
     }
-  }
-  if (SmackOptions::isEntryPoint(naming->get(*F))) {
-    emit(recordProcedureCall(F, {Attr::attr("cexpr", "smack:entry:" + naming->get(*F))}));
-    for (auto& A : F->getArgumentList()) {
-      emit(recordProcedureCall(&A, {Attr::attr("cexpr", "smack:arg:" + naming->get(*F) + ":" + naming->get(A))}));
+    if (SmackOptions::isEntryPoint(naming->get(*F))) {
+      emit(recordProcedureCall(F, {Attr::attr("cexpr", "smack:entry:" + naming->get(*F))}));
+      for (auto& A : F->getArgumentList()) {
+        emit(recordProcedureCall(&A, {Attr::attr("cexpr", "smack:arg:" + naming->get(*F) + ":" + naming->get(A))}));
+      }
     }
   }
 }
@@ -691,7 +691,7 @@ void SmackInstGenerator::visitDbgValueInst(llvm::DbgValueInst& dvi) {
       }
       Function* F = dvi.getFunction();
       for(auto &arg : F->args()) {
-        if (&arg == V) {
+        if (&arg == V && var->getScope() == F->getMetadata("dbg")) {
           emit(recordProcedureCall(V, {Attr::attr("cexpr", naming->get(*F) + ":arg:"+ var->getName().str())}));
           break;
         }

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -89,7 +89,7 @@ void SmackInstGenerator::annotate(llvm::Instruction& I, Block* B) {
     }
   }
 
-  if (SmackOptions::SourceLocSymbols && I.getMetadata("dbg") && &I != fstNonDebugInst) {
+  if (SmackOptions::SourceLocSymbols && I.getMetadata("dbg") && &I != firstNonDebugInst) {
     const DebugLoc DL = I.getDebugLoc();
     auto *scope = cast<DIScope>(DL.getScope());
     B->addStmt(Stmt::annot(Attr::attr("sourceloc", scope->getFilename().str(),
@@ -143,7 +143,7 @@ void SmackInstGenerator::visitBasicBlock(llvm::BasicBlock& bb) {
         continue;
       if (I.getDebugLoc()) {
         annotate(I, currBlock);
-        fstNonDebugInst = &I;
+        firstNonDebugInst = &I;
         break;
       }
     }

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -89,7 +89,7 @@ void SmackInstGenerator::annotate(llvm::Instruction& I, Block* B) {
     }
   }
 
-  if (SmackOptions::SourceLocSymbols && I.getMetadata("dbg")) {
+  if (SmackOptions::SourceLocSymbols && I.getMetadata("dbg") && &I != fstNonDebugInst) {
     const DebugLoc DL = I.getDebugLoc();
     auto *scope = cast<DIScope>(DL.getScope());
     B->addStmt(Stmt::annot(Attr::attr("sourceloc", scope->getFilename().str(),
@@ -137,15 +137,18 @@ void SmackInstGenerator::visitBasicBlock(llvm::BasicBlock& bb) {
   currBlock = getBlock(&bb);
 
   auto* F = bb.getParent();
-  if (SmackOptions::isEntryPoint(naming->get(*F)) && &bb == &F->getEntryBlock()) {
+  if (&bb == &F->getEntryBlock()) {
     for (auto& I : bb.getInstList()) {
       if (llvm::isa<llvm::DbgInfoIntrinsic>(I))
         continue;
       if (I.getDebugLoc()) {
         annotate(I, currBlock);
+        fstNonDebugInst = &I;
         break;
       }
     }
+  }
+  if (SmackOptions::isEntryPoint(naming->get(*F))) {
     emit(recordProcedureCall(F, {Attr::attr("cexpr", "smack:entry:" + naming->get(*F))}));
     for (auto& A : F->getArgumentList()) {
       emit(recordProcedureCall(&A, {Attr::attr("cexpr", "smack:arg:" + naming->get(*F) + ":" + naming->get(A))}));
@@ -670,7 +673,7 @@ void SmackInstGenerator::visitDbgValueInst(llvm::DbgValueInst& dvi) {
   processInstruction(dvi);
 
   if (SmackOptions::SourceLocSymbols) {
-    const Value* V = dvi.getValue();
+    Value* V = dvi.getValue();
     const llvm::DILocalVariable *var = dvi.getVariable();
     //if (V && !V->getType()->isPointerTy() && !llvm::isa<ConstantInt>(V)) {
     if (V && !V->getType()->isPointerTy()) {
@@ -683,10 +686,14 @@ void SmackInstGenerator::visitDbgValueInst(llvm::DbgValueInst& dvi) {
         const Instruction& pi = *std::prev(currInst);
         V = V->stripPointerCasts();
         WARN(i2s(pi));
-        if (!llvm::isa<const PHINode>(&pi) && V == llvm::dyn_cast<const Value>(&pi)) {
-          std::stringstream recordProc;
-          recordProc << "boogie_si_record_" << rep->type(V);
-          emit(Stmt::call(recordProc.str(), {rep->expr(V)}, {}, {Attr::attr("cexpr", var->getName().str())}));
+        if (!llvm::isa<const PHINode>(&pi) && V == llvm::dyn_cast<const Value>(&pi))
+          emit(recordProcedureCall(V, {Attr::attr("cexpr", var->getName().str())}));
+      }
+      Function* F = dvi.getFunction();
+      for(auto &arg : F->args()) {
+        if (&arg == V) {
+          emit(recordProcedureCall(V, {Attr::attr("cexpr", naming->get(*F) + ":arg:"+ var->getName().str())}));
+          break;
         }
       }
     }

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -89,7 +89,7 @@ void SmackInstGenerator::annotate(llvm::Instruction& I, Block* B) {
     }
   }
 
-  if (SmackOptions::SourceLocSymbols && I.getMetadata("dbg") && &I != firstNonDebugInst) {
+  if (SmackOptions::SourceLocSymbols && I.getMetadata("dbg")) {
     const DebugLoc DL = I.getDebugLoc();
     auto *scope = cast<DIScope>(DL.getScope());
     B->addStmt(Stmt::annot(Attr::attr("sourceloc", scope->getFilename().str(),
@@ -143,7 +143,6 @@ void SmackInstGenerator::visitBasicBlock(llvm::BasicBlock& bb) {
         continue;
       if (I.getDebugLoc()) {
         annotate(I, currBlock);
-        firstNonDebugInst = &I;
         break;
       }
     }


### PR DESCRIPTION
Currently SMACK doesn't emit record procedures for function arguments.  The `llvm.dbg.value` calls corresponding to function arguments are in the beginning of the entry block in a function. Source location annotations are not generated for these call instructions which must precede record procedure calls in order for them to work. This PR adds source location of the first non-debug instruction to the beginning of each block created.

Then values of non pointer function arguments will be printed as `function-name`:`arg`:`argument-name`.