### PR TITLE
Update Boogie and Corral links

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -51,6 +51,6 @@ tools and packages, which come with their own licenses:
 - LLVM, clang, LLVM runtime (http://llvm.org/)
 - mono (http://www.mono-project.com/)
 - Boogie (https://github.com/boogie-org/boogie/)
-- Corral (http://corral.codeplex.com/)
+- Corral (https://github.com/boogie-org/corral/)
 - Z3 (https://github.com/Z3Prover/z3/)
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ bitwise operations.
 
 Under the hood, SMACK is a translator from the [LLVM](http://www.llvm.org)
 compiler's popular intermediate representation (IR) into the
-[Boogie](http://boogie.codeplex.com) intermediate verification language (IVL).
+[Boogie](https://github.com/boogie-org/boogie) intermediate verification language (IVL).
 Sourcing LLVM IR exploits an increasing number of compiler front-ends,
 optimizations, and analyses. Currently SMACK only supports the C language via
 the [Clang](http://clang.llvm.org) compiler, though we are working on providing
 support for additional languages. Targeting Boogie exploits a canonical
 platform which simplifies the implementation of algorithms for verification,
 model checking, and abstract interpretation. Currently, SMACK leverages the
-[Boogie](http://boogie.codeplex.com) and [Corral](http://corral.codeplex.com)
+[Boogie](https://github.com/boogie-org/boogie) and [Corral](https://github.com/boogie-org/corral)
 verifiers.
 
 See below for system requirements, installation, usage, and everything else.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -172,7 +172,7 @@ shell in the `test` directory by executing
 [Clang]: http://clang.llvm.org
 [Clang-3.9.1]: http://llvm.org/releases/download.html#3.9.1
 [Boogie]: https://github.com/boogie-org/boogie
-[Corral]: https://corral.codeplex.com/
+[Corral]: https://github.com/boogie-org/corral
 [Z3]: https://github.com/Z3Prover/z3/
 [Mono]: http://www.mono-project.com/
 [Cygwin]: https://www.cygwin.com


### PR DESCRIPTION
This PR updates the links to point to their GitHub repositories instead of Codeplex.