### PR TITLE
Fix C++ boolean header issues

### DIFF
--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -146,7 +146,11 @@ NONDET_DECL(__VERIFIER_nondet,long,double);
 #undef NONDET_DECL
 
 // Used in SVCOMP benchmarks
+#ifdef __cplusplus
+bool __VERIFIER_nondet_bool(void);
+#else
 _Bool __VERIFIER_nondet_bool(void);
+#endif
 unsigned char __VERIFIER_nondet_uchar(void);
 unsigned short __VERIFIER_nondet_ushort(void);
 unsigned __VERIFIER_nondet_uint(void);

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -207,11 +207,20 @@ unsigned long long int __VERIFIER_nondet_unsigned_long_long_int(void) {
 }
 
 // Used in SVCCOMP benchmarks
+
+#ifdef __cplusplus
+bool __VERIFIER_nondet_bool(void) {
+  bool x = (bool)__VERIFIER_nondet_int();
+  __VERIFIER_assume(x == 0 || x == 1);
+  return x;
+}
+#else
 _Bool __VERIFIER_nondet_bool(void) {
   _Bool x = (_Bool)__VERIFIER_nondet_int();
   __VERIFIER_assume(x == 0 || x == 1);
   return x;
 }
+#endif
 
 unsigned char __VERIFIER_nondet_uchar(void) {
   unsigned char x = __VERIFIER_nondet_unsigned_char();

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -296,22 +296,6 @@ def smack_headers():
 def smack_lib():
   return os.path.join(smack_root(), 'share', 'smack', 'lib')
 
-def objc_clang_compile_command(args, lib = False):
-  cmd = default_clang_compile_command(args,lib)
-  if sys.platform in ['linux', 'linux2']:
-    objc_flags = try_command(['gnustep-config', '--objc-flags'])
-    cmd += objc_flags.split()
-  elif sys.platform == 'darwin':
-    sys.exit("Objective-C not yet supported on macOS")
-  else:
-    sys.exit("Objective-C not supported for this operating system.")
-  return cmd
-
-def cplusplus_clang_compile_command(args, lib = False):
-  cmd = default_clang_compile_command(args,lib)
-  cmd[0] = 'clang++'
-  return cmd
-
 def default_clang_compile_command(args, lib = False):
   cmd = ['clang', '-c', '-emit-llvm', '-O0', '-g', '-gcolumn-info']
   cmd += map(lambda path: '-I' + path, smack_headers())
@@ -365,12 +349,21 @@ def clang_frontend(args):
 
 def clang_plusplus_frontend(args):
   """Generate Boogie code from C++ language source(s)."""
-  compile_command = cplusplus_clang_compile_command(args)
-  clang_frontend_helper(compile_command, args)
+  compile_command = default_clang_compile_command(args)
+  compile_command[0] = 'clang++'
+  default_link_bc_files(compile_command, args)
 
 def objc_clang_frontend(args):
   """Generate Boogie code from Objective-C language source(s)."""
 
+  compile_command = default_clang_compile_command(args)
+  if sys.platform in ['linux', 'linux2']:
+    objc_flags = try_command(['gnustep-config', '--objc-flags'])
+    compile_command += objc_flags.split()
+  elif sys.platform == 'darwin':
+    sys.exit("Objective-C not yet supported on macOS")
+  else:
+    sys.exit("Objective-C not supported for this operating system.")
   compile_command = objc_clang_compile_command(args)
   default_link_bc_files(compile_command, args)
 

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -21,8 +21,8 @@ def frontends():
   return {
     'c': clang_frontend,
     'i': clang_frontend,
-    'cc': clang_frontend,
-    'cpp': clang_frontend,
+    'cc': clang_plusplus_frontend,
+    'cpp': clang_plusplus_frontend,
     'm': objc_clang_frontend,
     'json': json_compilation_database_frontend,
     'svcomp': svcomp_frontend,
@@ -307,6 +307,11 @@ def objc_clang_compile_command(args, lib = False):
     sys.exit("Objective-C not supported for this operating system.")
   return cmd
 
+def cplusplus_clang_compile_command(args, lib = False):
+  cmd = default_clang_compile_command(args,lib)
+  cmd[0] = 'clang++'
+  return cmd
+
 def default_clang_compile_command(args, lib = False):
   cmd = ['clang', '-c', '-emit-llvm', '-O0', '-g', '-gcolumn-info']
   cmd += map(lambda path: '-I' + path, smack_headers())
@@ -357,6 +362,11 @@ def clang_frontend(args):
 
   compile_command = default_clang_compile_command(args)
   default_link_bc_files(compile_command, args)
+
+def clang_plusplus_frontend(args):
+  """Generate Boogie code from C++ language source(s)."""
+  compile_command = cplusplus_clang_compile_command(args)
+  clang_frontend_helper(compile_command, args)
 
 def objc_clang_frontend(args):
   """Generate Boogie code from Objective-C language source(s)."""


### PR DESCRIPTION
Currently, when SMACK runs on a C++ file, clang fails with issues in smack.h and smack.c. This fixes them, and changes the command in top.py from `clang` to `clang++`.

Depends on #283 