### PR TITLE
D support

### DIFF
--- a/share/smack/include/smack.di
+++ b/share/smack/include/smack.di
@@ -1,0 +1,4 @@
+
+extern (C): void __VERIFIER_assert(int);
+
+//extern (C): void __smack_assert(int);

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -364,7 +364,6 @@ def objc_clang_frontend(args):
     sys.exit("Objective-C not yet supported on macOS")
   else:
     sys.exit("Objective-C not supported for this operating system.")
-  compile_command = objc_clang_compile_command(args)
   default_link_bc_files(compile_command, args)
 
 def default_link_bc_files(compile_command, args):

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -24,6 +24,7 @@ def frontends():
     'cc': clang_plusplus_frontend,
     'cpp': clang_plusplus_frontend,
     'm': objc_clang_frontend,
+    'd' : d_frontend,
     'json': json_compilation_database_frontend,
     'svcomp': svcomp_frontend,
     'bc': llvm_frontend,
@@ -364,6 +365,16 @@ def objc_clang_frontend(args):
     sys.exit("Objective-C not yet supported on macOS")
   else:
     sys.exit("Objective-C not supported for this operating system.")
+  default_link_bc_files(compile_command, args)
+
+def d_frontend(args):
+  """Generate Boogie code from D programming language source(s)."""
+
+  # note: -g and -O0 are not used here. 
+  # Right now, it works, and with these options, smack crashes.
+  compile_command = ['ldc2', '-output-ll'] 
+  compile_command += map(lambda path: '-I=' + path, smack_headers())
+  args.entry_points += ['_Dmain']
   default_link_bc_files(compile_command, args)
 
 def default_link_bc_files(compile_command, args):


### PR DESCRIPTION
This adds top.py support for D. 

Unfortunately, we can't test this with D files until we upgrade to Ubuntu 16.04. Right now, ldc doesn't have a version for Ubuntu 14.04 that can be installed with a package manager. When we have 16.04, we can test this. However, I still think it's good to put in right now while it's in the foreground of our attention.

For the same reason, build.sh hasn't been modified to have an INSTALL_D option. In fact, it's obscure enough and simple enough that I almost don't think we should pollute build.sh with D.