### PR TITLE
Fix phi nodes that get their values from a loop body

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ add_library(smackTranslator STATIC
   include/smack/VectorOperations.h
   include/smack/MemorySafetyChecker.h
   include/smack/IntegerOverflowChecker.h
+  include/smack/NormalizeLoops.h
   include/smack/SplitAggregateValue.h
   lib/smack/AddTiming.cpp
   lib/smack/BoogieAst.cpp
@@ -198,6 +199,7 @@ add_library(smackTranslator STATIC
   lib/smack/VectorOperations.cpp
   lib/smack/MemorySafetyChecker.cpp
   lib/smack/IntegerOverflowChecker.cpp
+  lib/smack/NormalizeLoops.cpp
   lib/smack/SplitAggregateValue.cpp
 )
 

--- a/include/smack/NormalizeLoops.h
+++ b/include/smack/NormalizeLoops.h
@@ -1,0 +1,24 @@
+//
+// This file is distributed under the MIT License. See LICENSE for details.
+//
+#ifndef NORMALIZELOOPS_H
+#define NORMALIZELOOPS_H
+
+#include "llvm/Pass.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Instructions.h"
+#include <map>
+
+namespace smack {
+
+class NormalizeLoops: public llvm::ModulePass {
+public:
+  static char ID; // Pass identification, replacement for typeid
+  NormalizeLoops() : llvm::ModulePass(ID) {}
+  const char* getPassName() const override;
+  virtual bool runOnModule(llvm::Module& m) override;
+  virtual void getAnalysisUsage(llvm::AnalysisUsage&) const override;
+};
+}
+
+#endif //NORMALIZELOOPS_H

--- a/lib/smack/NormalizeLoops.cpp
+++ b/lib/smack/NormalizeLoops.cpp
@@ -1,0 +1,154 @@
+//
+// This file is distributed under the MIT License. See LICENSE for details.
+//
+
+//
+// This pass normalizes loop structures to allow easier generation of Boogie
+// code when a loop edge comes from a branch. Specifically, a forwarding block
+// is added between a branching block and the loop header.
+//
+
+#include "smack/NormalizeLoops.h"
+#include "smack/Naming.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/ValueSymbolTable.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/IR/Dominators.h"
+#include "llvm/Support/raw_ostream.h"
+#include <map>
+#include <vector>
+#include <set>
+
+namespace smack {
+
+using namespace llvm;
+
+// Register LoopInfo
+void NormalizeLoops::getAnalysisUsage(AnalysisUsage& AU) const {
+  AU.addRequired<LoopInfoWrapperPass>();
+}
+
+/**
+ * Creates a basic block which unconditionally branches to \param target.
+ */
+BasicBlock* makeForwardingBlock(BasicBlock* target) {
+  auto& context = target->getContext();
+  BasicBlock* result = BasicBlock::Create(context, "forwarder", target->getParent());
+  BranchInst* branch = BranchInst::Create(target);
+  result->getInstList().push_back(branch);
+  return result;
+}
+
+/**
+ * Returns a vector of each successor index in \param ti which equals \param
+ * headerBlock.
+ */
+std::vector<unsigned> getSuccessorIndices(TerminatorInst* ti, BasicBlock* headerBlock) {
+  std::vector<unsigned> result;
+  unsigned numSuccs = ti->getNumSuccessors();
+  
+  if (numSuccs <= 1) { return result; }
+  
+  for (unsigned i = 0; i < numSuccs; ++i) {
+    if (ti->getSuccessor(i) == headerBlock) {
+      result.push_back(i);
+    }
+  }
+  return result;
+}
+
+/**
+ * Splits any edge between \param BB and \param headerBlock in a loop body,
+ * by adding a forwarding block between \param BB and \param headerBlock. The
+ * \param blockMap is updated to map between \param BB and the newly created
+ * forwarding block.
+ */
+void splitBlock(BasicBlock* BB, BasicBlock* headerBlock,
+                std::map<BasicBlock*, BasicBlock*>& blockMap) {
+  TerminatorInst* ti = BB->getTerminator();
+
+  // Get a list of all successor indices which point to headerBlock.
+  std::vector<unsigned> succIndices = getSuccessorIndices(ti, headerBlock);
+
+  // TerminatorInsts may have the header block listed multiple times as a
+  // successor block, e.g., in a SwitchInst. We need to make sure each such
+  // index uses the same forwarding block.
+  if (succIndices.size()) {
+    BasicBlock* forwarder = makeForwardingBlock(headerBlock);
+    blockMap[BB] = forwarder;
+    for (auto succIndex : succIndices) {
+      ti->setSuccessor(succIndex, forwarder);
+    }
+  }
+}
+
+/**
+ * \param blockMap a map from old BasicBlocks and new BasicBlocks.
+ * Fixes any PHI nodes in \param phis to get their incoming block from the new
+ * blocks in \param blockMap.
+ */
+void processPhis(std::vector<PHINode*>& phis, std::map<BasicBlock*, BasicBlock*>& blockMap) {
+  for (PHINode* phi : phis) {
+    unsigned numIncoming = phi->getNumIncomingValues();
+    for (unsigned i = 0; i < numIncoming; ++i) {
+      BasicBlock* incomingBlock = phi->getIncomingBlock(i);
+      if (blockMap.count(incomingBlock)) {
+        phi->setIncomingBlock(i, blockMap[incomingBlock]);
+      }
+    }
+  }
+}
+
+void processLoop(Loop *loop) {
+  std::vector<PHINode*> phis;
+  std::set<BasicBlock*> phiIncBlocks;
+  std::set<BasicBlock*> loopBlocks(loop->block_begin(), loop->block_end());
+  BasicBlock* headerBlock = loop->getHeader();
+  errs() << headerBlock->getParent()->getName() << ": " << *loop << "\n";
+  // Gather Phis in the header
+  for (Instruction& I : *headerBlock) {
+    if (auto* phi = dyn_cast<PHINode>(&I)) {
+      phis.push_back(phi);
+      phiIncBlocks.insert(phi->block_begin(), phi->block_end());
+    }
+  }
+
+  std::map<BasicBlock*, BasicBlock*> blockMap;
+
+  // Add forwarding blocks
+  for (BasicBlock* BB : phiIncBlocks) {
+    if (loopBlocks.count(BB) == 0) { continue; }
+    splitBlock(BB, headerBlock, blockMap);
+  }
+
+  // Fix up Phi nodes
+  processPhis(phis, blockMap);
+
+  // Handle subloops
+  for (Loop *subloop : loop->getSubLoops()) {
+    processLoop(subloop);
+  }
+}
+
+bool NormalizeLoops::runOnModule(Module& m) {
+  for (auto F = m.begin(), FEnd = m.end(); F != FEnd; ++F) {
+    if (F->isIntrinsic() || F->empty()) { continue; }
+    LoopInfo& loopInfo = getAnalysis<LoopInfoWrapperPass>(*F).getLoopInfo();
+    for (LoopInfo::iterator LI = loopInfo.begin(), LIEnd = loopInfo.end(); LI != LIEnd; ++LI) {
+      processLoop(*LI);
+    }
+  }
+
+  return true;
+}
+
+// Pass ID variable
+char NormalizeLoops::ID = 0;
+
+const char* NormalizeLoops::getPassName() const {
+  return "NormalizeLoops";
+}
+}

--- a/lib/smack/NormalizeLoops.cpp
+++ b/lib/smack/NormalizeLoops.cpp
@@ -17,7 +17,6 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/IR/Dominators.h"
-#include "llvm/Support/raw_ostream.h"
 #include <map>
 #include <vector>
 #include <set>
@@ -107,7 +106,7 @@ void processLoop(Loop *loop) {
   std::set<BasicBlock*> phiIncBlocks;
   std::set<BasicBlock*> loopBlocks(loop->block_begin(), loop->block_end());
   BasicBlock* headerBlock = loop->getHeader();
-  errs() << headerBlock->getParent()->getName() << ": " << *loop << "\n";
+
   // Gather Phis in the header
   for (Instruction& I : *headerBlock) {
     if (auto* phi = dyn_cast<PHINode>(&I)) {

--- a/tools/llvm2bpl/llvm2bpl.cpp
+++ b/tools/llvm2bpl/llvm2bpl.cpp
@@ -41,6 +41,7 @@
 #include "smack/MemorySafetyChecker.h"
 #include "smack/IntegerOverflowChecker.h"
 #include "smack/SplitAggregateValue.h"
+#include "smack/NormalizeLoops.h"
 
 static llvm::cl::opt<std::string>
 InputFilename(llvm::cl::Positional, llvm::cl::desc("<input LLVM bitcode file>"),
@@ -158,6 +159,7 @@ int main(int argc, char **argv) {
   }
 
   //pass_manager.add(new llvm::StructRet());
+  pass_manager.add(new smack::NormalizeLoops());
   pass_manager.add(new llvm::SimplifyEV());
   pass_manager.add(new llvm::SimplifyIV());
   pass_manager.add(new smack::ExtractContracts());


### PR DESCRIPTION
This adds an LLVM pass to fix #314.

Specifically, if a phi node in a loop header gets its value from a block in the loop body, and the source block branches when terminating, the generated Boogie code incorrectly updates the variable corresponding to the phi node.  To fix this, a forwarding block is added between the source block and the header. The generated Boogie code then updates the value for the phi node in the forwarding block, and other destination blocks keep the non-updated value for the phi node. Loops of this form are usually generated when compiling with optimization.