### PR TITLE
Avoid mem safety region collapse

### DIFF
--- a/include/smack/MemorySafetyChecker.h
+++ b/include/smack/MemorySafetyChecker.h
@@ -5,17 +5,35 @@
 #define MEMORYSAFETYCHECKER_H
 
 #include "llvm/Pass.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/InstVisitor.h"
+#include <map>
 
 namespace smack {
   
-class MemorySafetyChecker: public llvm::ModulePass {
+class MemorySafetyChecker: public llvm::ModulePass, public llvm::InstVisitor<MemorySafetyChecker> {
+private:
+  std::map<llvm::Module*, llvm::Function*> leakCheckFunction;
+  std::map<llvm::Module*, llvm::Function*> safetyCheckFunction;
+
+  llvm::Function* getLeakCheckFunction(llvm::Module& M);
+  llvm::Function* getSafetyCheckFunction(llvm::Module& M);
+
+  void insertMemoryLeakCheck(llvm::Instruction* I);
+  void insertMemoryAccessCheck(llvm::Value* addr, llvm::Value* size, llvm::Instruction* I);
+
 public:
   static char ID; // Pass identification, replacement for typeid
   MemorySafetyChecker() : llvm::ModulePass(ID) {}
   virtual bool runOnModule(llvm::Module& m);
+
+  void visitReturnInst(llvm::ReturnInst& I);
+  void visitLoadInst(llvm::LoadInst& I);
+  void visitStoreInst(llvm::StoreInst& I);
+  void visitMemSetInst(llvm::MemSetInst& I);
+  void visitMemTransferInst(llvm::MemTransferInst& I);
 };
 
 }
 
 #endif //MEMORYSAFETYCHECKER_H
-

--- a/include/smack/MemorySafetyChecker.h
+++ b/include/smack/MemorySafetyChecker.h
@@ -10,8 +10,8 @@
 #include <map>
 
 namespace smack {
-  
-class MemorySafetyChecker: public llvm::ModulePass, public llvm::InstVisitor<MemorySafetyChecker> {
+
+class MemorySafetyChecker: public llvm::FunctionPass, public llvm::InstVisitor<MemorySafetyChecker> {
 private:
   std::map<llvm::Module*, llvm::Function*> leakCheckFunction;
   std::map<llvm::Module*, llvm::Function*> safetyCheckFunction;
@@ -24,8 +24,8 @@ private:
 
 public:
   static char ID; // Pass identification, replacement for typeid
-  MemorySafetyChecker() : llvm::ModulePass(ID) {}
-  virtual bool runOnModule(llvm::Module& m);
+  MemorySafetyChecker() : llvm::FunctionPass(ID) {}
+  virtual bool runOnFunction(llvm::Function& F);
 
   void visitReturnInst(llvm::ReturnInst& I);
   void visitLoadInst(llvm::LoadInst& I);

--- a/lib/smack/MemorySafetyChecker.cpp
+++ b/lib/smack/MemorySafetyChecker.cpp
@@ -40,8 +40,13 @@ void inserMemoryAccessCheck(Value* memoryPointer, Instruction* I, DataLayout* da
 
 bool MemorySafetyChecker::runOnModule(Module& m) {
   DataLayout* dataLayout = new DataLayout(&m);
-  Function* memorySafetyFunction = m.getFunction(Naming::MEMORY_SAFETY_FUNCTION);
+  LLVMContext& C = m.getContext();
+
+  Function* memorySafetyFunction = dyn_cast<Function>(m.getOrInsertFunction(Naming::MEMORY_SAFETY_FUNCTION, FunctionType::get(Type::getVoidTy(C), {PointerType::getUnqual(Type::getInt8Ty(C)), Type::getInt64Ty(C)}, false)));
   assert(memorySafetyFunction != NULL && "Memory safety function must be present.");
+  memorySafetyFunction->addFnAttr(Attribute::AttrKind::ReadNone);
+  memorySafetyFunction->addFnAttr(Attribute::AttrKind::NoUnwind);
+
   for (auto& F : m) {
     if (!Naming::isSmackName(F.getName())) {
       if (SmackOptions::isEntryPoint(F.getName())) {
@@ -78,4 +83,3 @@ bool MemorySafetyChecker::runOnModule(Module& m) {
 // Pass ID variable
 char MemorySafetyChecker::ID = 0;
 }
-

--- a/lib/smack/MemorySafetyChecker.cpp
+++ b/lib/smack/MemorySafetyChecker.cpp
@@ -16,68 +16,95 @@ namespace smack {
 
 using namespace llvm;
 
-void insertMemoryLeakCheck(Function& F, Module& m) {
-  Function* memoryLeakCheckFunction = m.getFunction(Naming::MEMORY_LEAK_FUNCTION);
-  assert (memoryLeakCheckFunction != NULL && "Memory leak check function must be present.");
-  for (inst_iterator I = inst_begin(F), E = inst_end(F); I != E; ++I) {
-    if (isa<ReturnInst>(&*I)) {
-      CallInst::Create(memoryLeakCheckFunction, "", &*I);
-    }
-  }
-}
-
-void inserMemoryAccessCheck(Value* memoryPointer, Instruction* I, DataLayout* dataLayout, Function* memorySafetyFunction, Function* F) {
-  // Finding the exact type of the second argument to our memory safety function
-  Type* sizeType = memorySafetyFunction->getFunctionType()->getParamType(1);
-  PointerType* pointerType = cast<PointerType>(memoryPointer->getType());
-  uint64_t storeSize = dataLayout->getTypeStoreSize(pointerType->getPointerElementType());
-  Value* size = ConstantInt::get(sizeType, storeSize);
-  Type *voidPtrTy = PointerType::getUnqual(IntegerType::getInt8Ty(F->getContext()));
-  CastInst* castPointer = CastInst::Create(Instruction::BitCast, memoryPointer, voidPtrTy, "", &*I);
-  Value* args[] = {castPointer, size};
-  CallInst::Create(memorySafetyFunction, ArrayRef<Value*>(args, 2), "", &*I);
-}
-
-bool MemorySafetyChecker::runOnModule(Module& m) {
-  DataLayout* dataLayout = new DataLayout(&m);
-  LLVMContext& C = m.getContext();
-
-  Function* memorySafetyFunction = dyn_cast<Function>(m.getOrInsertFunction(Naming::MEMORY_SAFETY_FUNCTION, FunctionType::get(Type::getVoidTy(C), {PointerType::getUnqual(Type::getInt8Ty(C)), Type::getInt64Ty(C)}, false)));
-  assert(memorySafetyFunction != NULL && "Memory safety function must be present.");
-  memorySafetyFunction->addFnAttr(Attribute::AttrKind::ReadNone);
-  memorySafetyFunction->addFnAttr(Attribute::AttrKind::NoUnwind);
-
-  for (auto& F : m) {
-    if (!Naming::isSmackName(F.getName())) {
-      if (SmackOptions::isEntryPoint(F.getName())) {
-        insertMemoryLeakCheck(F, m);
-      }
-      for (inst_iterator I = inst_begin(F), E = inst_end(F); I != E; ++I) {
-        if (LoadInst* li = dyn_cast<LoadInst>(&*I)) {
-          inserMemoryAccessCheck(li->getPointerOperand(), &*I, dataLayout, memorySafetyFunction, &F);
-        } else if (StoreInst* si = dyn_cast<StoreInst>(&*I)) {
-          inserMemoryAccessCheck(si->getPointerOperand(), &*I, dataLayout, memorySafetyFunction, &F);
-        } else if (MemSetInst* memseti = dyn_cast<MemSetInst>(&*I)) {
-	    Value* dest = memseti->getDest();
-	    Value* size = memseti->getLength();
-	    Type* voidPtrTy = PointerType::getUnqual(IntegerType::getInt8Ty(F.getContext()));
-	    CastInst* castPtr = CastInst::Create(Instruction::BitCast, dest, voidPtrTy, "", &*I);
-	    CallInst::Create(memorySafetyFunction, {castPtr, size}, "", &*I);
-        } else if (MemTransferInst* memtrni = dyn_cast<MemTransferInst>(&*I)) {
-            // MemTransferInst is abstract class for both MemCpyInst and MemMoveInst
-	    Value* dest = memtrni->getDest();
-	    Value* src = memtrni->getSource();
-	    Value* size = memtrni->getLength();
-	    Type* voidPtrTy = PointerType::getUnqual(IntegerType::getInt8Ty(F.getContext()));
-	    CastInst* castPtrDest = CastInst::Create(Instruction::BitCast, dest, voidPtrTy, "", &*I);
-	    CastInst* castPtrSrc = CastInst::Create(Instruction::BitCast, src, voidPtrTy, "", &*I);
-	    CallInst::Create(memorySafetyFunction, {castPtrDest, size}, "", &*I);  
-	    CallInst::Create(memorySafetyFunction, {castPtrSrc, size}, "", &*I);  
+Function* MemorySafetyChecker::getLeakCheckFunction(Module& M) {
+  if (!leakCheckFunction.count(&M)) {
+    auto F = M.getFunction(Naming::MEMORY_LEAK_FUNCTION);
+    assert (F && "Memory leak check function must be present.");
+    leakCheckFunction[&M] = F;
 	}
+  return leakCheckFunction[&M];
       }
-    }
+
+Function* MemorySafetyChecker::getSafetyCheckFunction(Module& M) {
+  if (!safetyCheckFunction.count(&M)) {
+    auto& C = M.getContext();
+    auto T = PointerType::getUnqual(Type::getInt8Ty(C));
+    auto F = dyn_cast<Function>(M.getOrInsertFunction(
+      Naming::MEMORY_SAFETY_FUNCTION,
+      FunctionType::get(Type::getVoidTy(C), {T, T}, false)));
+    assert(F && "Memory safety function must be present.");
+    F->addFnAttr(Attribute::AttrKind::ReadNone);
+    F->addFnAttr(Attribute::AttrKind::NoUnwind);
+    safetyCheckFunction[&M] = F;
   }
+  return safetyCheckFunction[&M];
+}
+
+void MemorySafetyChecker::insertMemoryLeakCheck(Instruction* I) {
+  auto& M = *I->getParent()->getParent()->getParent();
+  CallInst::Create(getLeakCheckFunction(M), "", I);
+    }
+
+void MemorySafetyChecker::insertMemoryAccessCheck(Value* addr, Value* size, Instruction* I) {
+  auto& M = *I->getParent()->getParent()->getParent();
+  auto& C = M.getContext();
+  auto T = PointerType::getUnqual(Type::getInt8Ty(C));
+  CallInst::Create(getSafetyCheckFunction(M), {
+    CastInst::Create(Instruction::BitCast, addr, T, "", I),
+    CastInst::Create(Instruction::BitCast, size, T, "", I)
+  }, "", I);
+  }
+
+bool MemorySafetyChecker::runOnModule(Module& M) {
+  this->visit(M);
   return true;
+}
+
+void MemorySafetyChecker::visitReturnInst(llvm::ReturnInst& I) {
+  auto& F = *I.getParent()->getParent();
+  if (!Naming::isSmackName(F.getName()))
+    if (SmackOptions::isEntryPoint(F.getName()))
+      insertMemoryLeakCheck(&I);
+}
+
+namespace {
+  Value* accessSizeAsPointer(Module& M, Value* V) {
+    auto T = dyn_cast<PointerType>(V->getType());
+    assert(T && "expected pointer type");
+
+    return ConstantExpr::getIntToPtr(
+      ConstantInt::get(
+        Type::getInt64Ty(M.getContext()),
+        M.getDataLayout().getTypeStoreSize(T->getPointerElementType())),
+      PointerType::getUnqual(Type::getInt8Ty(M.getContext())));
+  }
+
+  Value* accessSizeAsPointer(LoadInst& I) {
+    auto& M = *I.getParent()->getParent()->getParent();
+    return accessSizeAsPointer(M, I.getPointerOperand());
+  }
+
+  Value* accessSizeAsPointer(StoreInst& I) {
+    auto& M = *I.getParent()->getParent()->getParent();
+    return accessSizeAsPointer(M, I.getPointerOperand());
+  }
+}
+
+void MemorySafetyChecker::visitLoadInst(LoadInst& I) {
+  insertMemoryAccessCheck(I.getPointerOperand(), accessSizeAsPointer(I), &I);
+}
+
+void MemorySafetyChecker::visitStoreInst(StoreInst& I) {
+  insertMemoryAccessCheck(I.getPointerOperand(), accessSizeAsPointer(I), &I);
+}
+
+void MemorySafetyChecker::visitMemSetInst(MemSetInst& I) {
+  insertMemoryAccessCheck(I.getDest(), I.getLength(), &I);
+}
+
+void MemorySafetyChecker::visitMemTransferInst(MemTransferInst& I) {
+  insertMemoryAccessCheck(I.getDest(), I.getLength(), &I);
+  insertMemoryAccessCheck(I.getSource(), I.getLength(), &I);
 }
 
 // Pass ID variable

--- a/lib/smack/MemorySafetyChecker.cpp
+++ b/lib/smack/MemorySafetyChecker.cpp
@@ -55,15 +55,16 @@ void MemorySafetyChecker::insertMemoryAccessCheck(Value* addr, Value* size, Inst
   }, "", I);
 }
 
-bool MemorySafetyChecker::runOnModule(Module& M) {
-  this->visit(M);
+bool MemorySafetyChecker::runOnFunction(Function& F) {
+  if (Naming::isSmackName(F.getName()))
+    return false;
+
+  this->visit(F);
   return true;
 }
 
 void MemorySafetyChecker::visitReturnInst(llvm::ReturnInst& I) {
   auto& F = *I.getParent()->getParent();
-  if (Naming::isSmackName(F.getName()))
-    return;
 
   if (SmackOptions::isEntryPoint(F.getName()))
     insertMemoryLeakCheck(&I);
@@ -93,34 +94,18 @@ namespace {
 }
 
 void MemorySafetyChecker::visitLoadInst(LoadInst& I) {
-  auto& F = *I.getParent()->getParent();
-  if (Naming::isSmackName(F.getName()))
-    return;
-
   insertMemoryAccessCheck(I.getPointerOperand(), accessSizeAsPointer(I), &I);
 }
 
 void MemorySafetyChecker::visitStoreInst(StoreInst& I) {
-  auto& F = *I.getParent()->getParent();
-  if (Naming::isSmackName(F.getName()))
-    return;
-
   insertMemoryAccessCheck(I.getPointerOperand(), accessSizeAsPointer(I), &I);
 }
 
 void MemorySafetyChecker::visitMemSetInst(MemSetInst& I) {
-  auto& F = *I.getParent()->getParent();
-  if (Naming::isSmackName(F.getName()))
-    return;
-
   insertMemoryAccessCheck(I.getDest(), I.getLength(), &I);
 }
 
 void MemorySafetyChecker::visitMemTransferInst(MemTransferInst& I) {
-  auto& F = *I.getParent()->getParent();
-  if (Naming::isSmackName(F.getName()))
-    return;
-
   insertMemoryAccessCheck(I.getDest(), I.getLength(), &I);
   insertMemoryAccessCheck(I.getSource(), I.getLength(), &I);
 }

--- a/lib/smack/MemorySafetyChecker.cpp
+++ b/lib/smack/MemorySafetyChecker.cpp
@@ -21,9 +21,9 @@ Function* MemorySafetyChecker::getLeakCheckFunction(Module& M) {
     auto F = M.getFunction(Naming::MEMORY_LEAK_FUNCTION);
     assert (F && "Memory leak check function must be present.");
     leakCheckFunction[&M] = F;
-	}
+  }
   return leakCheckFunction[&M];
-      }
+}
 
 Function* MemorySafetyChecker::getSafetyCheckFunction(Module& M) {
   if (!safetyCheckFunction.count(&M)) {
@@ -43,7 +43,7 @@ Function* MemorySafetyChecker::getSafetyCheckFunction(Module& M) {
 void MemorySafetyChecker::insertMemoryLeakCheck(Instruction* I) {
   auto& M = *I->getParent()->getParent()->getParent();
   CallInst::Create(getLeakCheckFunction(M), "", I);
-    }
+}
 
 void MemorySafetyChecker::insertMemoryAccessCheck(Value* addr, Value* size, Instruction* I) {
   auto& M = *I->getParent()->getParent()->getParent();
@@ -53,7 +53,7 @@ void MemorySafetyChecker::insertMemoryAccessCheck(Value* addr, Value* size, Inst
     CastInst::Create(Instruction::BitCast, addr, T, "", I),
     CastInst::CreateBitOrPointerCast(size, T, "", I)
   }, "", I);
-  }
+}
 
 bool MemorySafetyChecker::runOnModule(Module& M) {
   this->visit(M);

--- a/lib/smack/MemorySafetyChecker.cpp
+++ b/lib/smack/MemorySafetyChecker.cpp
@@ -51,7 +51,7 @@ void MemorySafetyChecker::insertMemoryAccessCheck(Value* addr, Value* size, Inst
   auto T = PointerType::getUnqual(Type::getInt8Ty(C));
   CallInst::Create(getSafetyCheckFunction(M), {
     CastInst::Create(Instruction::BitCast, addr, T, "", I),
-    CastInst::Create(Instruction::BitCast, size, T, "", I)
+    CastInst::CreateBitOrPointerCast(size, T, "", I)
   }, "", I);
   }
 

--- a/lib/smack/MemorySafetyChecker.cpp
+++ b/lib/smack/MemorySafetyChecker.cpp
@@ -62,9 +62,11 @@ bool MemorySafetyChecker::runOnModule(Module& M) {
 
 void MemorySafetyChecker::visitReturnInst(llvm::ReturnInst& I) {
   auto& F = *I.getParent()->getParent();
-  if (!Naming::isSmackName(F.getName()))
-    if (SmackOptions::isEntryPoint(F.getName()))
-      insertMemoryLeakCheck(&I);
+  if (Naming::isSmackName(F.getName()))
+    return;
+
+  if (SmackOptions::isEntryPoint(F.getName()))
+    insertMemoryLeakCheck(&I);
 }
 
 namespace {
@@ -91,18 +93,34 @@ namespace {
 }
 
 void MemorySafetyChecker::visitLoadInst(LoadInst& I) {
+  auto& F = *I.getParent()->getParent();
+  if (Naming::isSmackName(F.getName()))
+    return;
+
   insertMemoryAccessCheck(I.getPointerOperand(), accessSizeAsPointer(I), &I);
 }
 
 void MemorySafetyChecker::visitStoreInst(StoreInst& I) {
+  auto& F = *I.getParent()->getParent();
+  if (Naming::isSmackName(F.getName()))
+    return;
+
   insertMemoryAccessCheck(I.getPointerOperand(), accessSizeAsPointer(I), &I);
 }
 
 void MemorySafetyChecker::visitMemSetInst(MemSetInst& I) {
+  auto& F = *I.getParent()->getParent();
+  if (Naming::isSmackName(F.getName()))
+    return;
+
   insertMemoryAccessCheck(I.getDest(), I.getLength(), &I);
 }
 
 void MemorySafetyChecker::visitMemTransferInst(MemTransferInst& I) {
+  auto& F = *I.getParent()->getParent();
+  if (Naming::isSmackName(F.getName()))
+    return;
+
   insertMemoryAccessCheck(I.getDest(), I.getLength(), &I);
   insertMemoryAccessCheck(I.getSource(), I.getLength(), &I);
 }

--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -41,7 +41,7 @@ smack_value_t __SMACK_return_value(void);
 #if MEMORY_SAFETY
 // Inserts memory access checks in form of assert to check null pointer access
 // and buffer overflow errors
-void __SMACK_check_memory_safety(void*, unsigned long);
+void __SMACK_check_memory_safety(void*, unsigned long) __attribute__((const));
 void __SMACK_check_memory_leak(void);
 #endif
 

--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -41,7 +41,7 @@ smack_value_t __SMACK_return_value(void);
 #if MEMORY_SAFETY
 // Inserts memory access checks in form of assert to check null pointer access
 // and buffer overflow errors
-void __SMACK_check_memory_safety(void*, unsigned long) __attribute__((const));
+void __SMACK_check_memory_safety(void*, void*) __attribute__((const));
 void __SMACK_check_memory_leak(void);
 #endif
 

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -1126,6 +1126,20 @@ void __SMACK_decls(void) {
     "}\n");
 
 #if MEMORY_SAFETY
+  __SMACK_dummy((int) __SMACK_check_memory_safety);
+  D("implementation __SMACK_check_memory_safety(p: ref, size: ref)\n"
+    "{\n"
+    "  assert {:valid_deref} $Alloc[$base(p)];\n"
+    "  assert {:valid_deref} $sle.ref.bool($base(p), p);\n"
+  #if MEMORY_MODEL_NO_REUSE_IMPLS
+    "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size($base(p))));\n"
+  #elif MEMORY_MODEL_REUSE
+    "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size[$base(p)]));\n"
+  #else
+    "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size($base(p))));\n"
+  #endif
+    "}\n");
+
   D("function $base(ref) returns (ref);");
   D("var $allocatedCounter: int;\n");
 
@@ -1309,19 +1323,6 @@ void __SMACK_decls(void) {
 }
 
 #if MEMORY_SAFETY
-// The size parameter represents number of bytes that are being accessed
-void __SMACK_check_memory_safety(void* pointer, void* sizeRef) {
-  __SMACK_code("assert {:valid_deref} $Alloc[$base(@)];", pointer);
-  __SMACK_code("assert {:valid_deref} $sle.ref.bool($base(@), @);", pointer, pointer);
-#if MEMORY_MODEL_NO_REUSE_IMPLS
-  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size($base(@))));", pointer, sizeRef, pointer, pointer);
-#elif MEMORY_MODEL_REUSE
-  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size[$base(@)]));", pointer, sizeRef, pointer, pointer);
-#else
-  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size($base(@))));", pointer, sizeRef, pointer, pointer);
-#endif
-}
-
 void __SMACK_check_memory_leak(void) {
   __SMACK_code("assert {:valid_memtrack} $allocatedCounter == 0;");
 }

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -1126,6 +1126,20 @@ void __SMACK_decls(void) {
     "}\n");
 
 #if MEMORY_SAFETY
+
+  D("implementation __SMACK_check_memory_safety(p: ref, size: i64)\n"
+    "{\n"
+    "  assert {:valid_deref} $Alloc[$base(p)] == true;\n"
+    "  assert {:valid_deref} $sle.ref.bool($base(p), p);\n"
+  #if MEMORY_MODEL_NO_REUSE_IMPLS
+    "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size($base(p))));\n"
+  #elif MEMORY_MODEL_REUSE
+    "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size($base(p))));\n"
+  #else
+    "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size($base(p))));\n"
+  #endif
+    "}\n");
+
   D("function $base(ref) returns (ref);");
   D("var $allocatedCounter: int;\n");
 

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -1126,7 +1126,6 @@ void __SMACK_decls(void) {
     "}\n");
 
 #if MEMORY_SAFETY
-
   D("function $base(ref) returns (ref);");
   D("var $allocatedCounter: int;\n");
 
@@ -1310,17 +1309,16 @@ void __SMACK_decls(void) {
 }
 
 #if MEMORY_SAFETY
-void __SMACK_check_memory_safety(void* addr, void* size) {
-  __SMACK_dummy(addr);
-  __SMACK_dummy(size);
-  __SMACK_code("assert {:valid_deref} $Alloc[$base(@)] == true;", addr);
-  __SMACK_code("assert {:valid_deref} $sle.ref.bool($base(@), @);", addr, addr);
+// The size parameter represents number of bytes that are being accessed
+void __SMACK_check_memory_safety(void* pointer, void* sizeRef) {
+  __SMACK_code("assert {:valid_deref} $Alloc[$base(@)];", pointer);
+  __SMACK_code("assert {:valid_deref} $sle.ref.bool($base(@), @);", pointer, pointer);
 #if MEMORY_MODEL_NO_REUSE_IMPLS
-  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size($base(@))));", addr, size, addr, addr);
+  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size($base(@))));", pointer, sizeRef, pointer, pointer);
 #elif MEMORY_MODEL_REUSE
-  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size[$base(@)]));", addr, size, addr, addr);
+  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size[$base(@)]));", pointer, sizeRef, pointer, pointer);
 #else
-  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size($base(@))));", addr, size, addr, addr);
+  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size($base(@))));", pointer, sizeRef, pointer, pointer);
 #endif
 }
 

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -1323,20 +1323,6 @@ void __SMACK_decls(void) {
 }
 
 #if MEMORY_SAFETY
-// The size parameter represents number of bytes that are being accessed
-void __SMACK_check_memory_safety(void* pointer, unsigned long size) {
-  void* sizeRef = (void*)size;
-  __SMACK_code("assert {:valid_deref} $Alloc[$base(@)];", pointer);
-  __SMACK_code("assert {:valid_deref} $sle.ref.bool($base(@), @);", pointer, pointer);
-#if MEMORY_MODEL_NO_REUSE_IMPLS
-  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size($base(@))));", pointer, sizeRef, pointer, pointer);
-#elif MEMORY_MODEL_REUSE
-  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size[$base(@)]));", pointer, sizeRef, pointer, pointer);
-#else
-  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size($base(@))));", pointer, sizeRef, pointer, pointer);
-#endif
-}
-
 void __SMACK_check_memory_leak(void) {
   __SMACK_code("assert {:valid_memtrack} $allocatedCounter == 0;");
 }

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -1127,7 +1127,7 @@ void __SMACK_decls(void) {
 
 #if MEMORY_SAFETY
 
-  D("implementation __SMACK_check_memory_safety(p: ref, size: i64)\n"
+  D("implementation __SMACK_check_memory_safety(p: ref, size: ref)\n"
     "{\n"
     "  assert {:valid_deref} $Alloc[$base(p)] == true;\n"
     "  assert {:valid_deref} $sle.ref.bool($base(p), p);\n"

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -1134,7 +1134,7 @@ void __SMACK_decls(void) {
   #if MEMORY_MODEL_NO_REUSE_IMPLS
     "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size($base(p))));\n"
   #elif MEMORY_MODEL_REUSE
-    "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size($base(p))));\n"
+    "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size[$base(p)]));\n"
   #else
     "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size($base(p))));\n"
   #endif

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -1127,19 +1127,6 @@ void __SMACK_decls(void) {
 
 #if MEMORY_SAFETY
 
-  D("implementation __SMACK_check_memory_safety(p: ref, size: ref)\n"
-    "{\n"
-    "  assert {:valid_deref} $Alloc[$base(p)] == true;\n"
-    "  assert {:valid_deref} $sle.ref.bool($base(p), p);\n"
-  #if MEMORY_MODEL_NO_REUSE_IMPLS
-    "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size($base(p))));\n"
-  #elif MEMORY_MODEL_REUSE
-    "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size[$base(p)]));\n"
-  #else
-    "  assert {:valid_deref} $sle.ref.bool($add.ref(p, size), $add.ref($base(p), $Size($base(p))));\n"
-  #endif
-    "}\n");
-
   D("function $base(ref) returns (ref);");
   D("var $allocatedCounter: int;\n");
 
@@ -1323,6 +1310,20 @@ void __SMACK_decls(void) {
 }
 
 #if MEMORY_SAFETY
+void __SMACK_check_memory_safety(void* addr, void* size) {
+  __SMACK_dummy(addr);
+  __SMACK_dummy(size);
+  __SMACK_code("assert {:valid_deref} $Alloc[$base(@)] == true;", addr);
+  __SMACK_code("assert {:valid_deref} $sle.ref.bool($base(@), @);", addr, addr);
+#if MEMORY_MODEL_NO_REUSE_IMPLS
+  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size($base(@))));", addr, size, addr, addr);
+#elif MEMORY_MODEL_REUSE
+  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size[$base(@)]));", addr, size, addr, addr);
+#else
+  __SMACK_code("assert {:valid_deref} $sle.ref.bool($add.ref(@, @), $add.ref($base(@), $Size($base(@))));", addr, size, addr, addr);
+#endif
+}
+
 void __SMACK_check_memory_leak(void) {
   __SMACK_code("assert {:valid_memtrack} $allocatedCounter == 0;");
 }


### PR DESCRIPTION
Attempting to salvage a possibly outdated fix for Issue #197 to avoid region collapse due to memory safety checking.