### PR TITLE
Rounding mode support

### DIFF
--- a/include/smack/BoogieAst.h
+++ b/include/smack/BoogieAst.h
@@ -38,6 +38,7 @@ public:
   static const Expr* lit(bool n, std::string s, std::string e, unsigned ss, unsigned es);
   static const Expr* neq(const Expr* l, const Expr* r);
   static const Expr* not_(const Expr* e);
+  static const Expr* rmode(std::string rm);
   static const Expr* sel(const Expr* b, const Expr* i);
   static const Expr* sel(std::string b, std::string i);
   static const Expr* upd(const Expr* b, const Expr* i, const Expr* v);
@@ -83,6 +84,13 @@ public:
   void print(std::ostream& os) const;
 };
 
+class RModeLit : public Expr {
+  std::string val;
+public:
+  RModeLit(std::string v) : val(v) {}
+  void print(std::ostream& os) const;
+};
+
 class IntLit : public Expr {
   std::string val;
 public:
@@ -99,6 +107,7 @@ public:
   }
   void print(std::ostream& os) const;
 };
+
 
 class BvLit : public Expr {
   std::string val;

--- a/include/smack/BoogieAst.h
+++ b/include/smack/BoogieAst.h
@@ -108,7 +108,6 @@ public:
   void print(std::ostream& os) const;
 };
 
-
 class BvLit : public Expr {
   std::string val;
   unsigned width;

--- a/include/smack/Naming.h
+++ b/include/smack/Naming.h
@@ -79,6 +79,7 @@ public:
   static const std::string RET_VAR;
   static const std::string EXN_VAR;
   static const std::string EXN_VAL_VAR;
+  static const std::string RMODE_VAR;
   static const std::string BOOL_VAR;
   static const std::string FLOAT_VAR;
   static const std::string INT_VAR;

--- a/lib/smack/BoogieAst.cpp
+++ b/lib/smack/BoogieAst.cpp
@@ -103,6 +103,10 @@ const Expr* Expr::not_(const Expr* e) {
   return new NotExpr(e);
 }
 
+const Expr* Expr::rmode(std::string v) {
+  return new RModeLit(v);
+}
+
 const Expr* Expr::sel(const Expr* b, const Expr* i) {
   return new SelExpr(b, i);
 }
@@ -417,6 +421,10 @@ void FunExpr::print(std::ostream& os) const {
 
 void BoolLit::print(std::ostream& os) const {
   os << (val ? "true" : "false");
+}
+
+void RModeLit::print(std::ostream& os) const {
+  os << val;
 }
 
 void IntLit::print(std::ostream& os) const {

--- a/lib/smack/Naming.cpp
+++ b/lib/smack/Naming.cpp
@@ -65,6 +65,7 @@ const std::string Naming::BLOCK_LBL = "$bb";
 const std::string Naming::RET_VAR = "$r";
 const std::string Naming::EXN_VAR = "$exn";
 const std::string Naming::EXN_VAL_VAR = "$exnv";
+const std::string Naming::RMODE_VAR = "$rmode";
 const std::string Naming::BOOL_VAR = "$b";
 const std::string Naming::FLOAT_VAR = "$f";
 const std::string Naming::INT_VAR = "$i";

--- a/lib/smack/SmackRep.cpp
+++ b/lib/smack/SmackRep.cpp
@@ -1156,6 +1156,7 @@ Decl* SmackRep::getInitFuncs() {
   Block* b = Block::block();
   for (auto name : initFuncs)
     b->addStmt(Stmt::call(name));
+  b->addStmt(Stmt::assign(Expr::id("$rmode"), Expr::rmode("RNE")));
   b->addStmt(Stmt::return_());
   proc->getBlocks().push_back(b);
   return proc;

--- a/share/smack/include/fenv.h
+++ b/share/smack/include/fenv.h
@@ -1,0 +1,16 @@
+// This file is distributed under the MIT License. See LICENSE for details.
+//
+
+#ifndef FENV_H
+#define FENV_H
+
+#define FE_TONEARESTEVEN 1
+#define FE_TONEARESTAWAY 2
+#define FE_UPWARD 3
+#define FE_DOWNWARD 4
+#define FE_TOWARDZERO 5
+
+int fegetround(void);
+int fesetround(int);
+
+#endif

--- a/share/smack/lib/fenv.c
+++ b/share/smack/lib/fenv.c
@@ -14,15 +14,6 @@ int fegetround()
 
 int fesetround(int rm) 
 {
-  /*char *rmStr;
-  switch (rm) {
-  case FE_TONEARESTEVEN: rmStr = "RNE"; break;
-  case FE_TONEARESTAWAY: rmStr = "RNA"; break;
-  case FE_UPWARD: rmStr = "RTP"; break;
-  case FE_DOWNWARD: rmStr = "RTN"; break;
-  case FE_TOWARDZERO: rmStr = "RTZ";
-  }
-  __SMACK_code("$rmode := @;", rmStr);*/
   switch (rm) {
   case FE_TONEARESTEVEN: __SMACK_code("$rmode := RNE;"); break;
   case FE_TONEARESTAWAY: __SMACK_code("$rmode := RNA;"); break;

--- a/share/smack/lib/fenv.c
+++ b/share/smack/lib/fenv.c
@@ -1,0 +1,35 @@
+#include <fenv.h>
+#include <smack.h>
+
+int fegetround()
+{
+  int ret = __VERIFIER_nondet_int();
+  __SMACK_code("if ($rmode == RNE) {@ := 1;}", ret);
+  __SMACK_code("if ($rmode == RNA) {@ := 2;}", ret);
+  __SMACK_code("if ($rmode == RTP) {@ := 3;}", ret);
+  __SMACK_code("if ($rmode == RTN) {@ := 4;}", ret);
+  __SMACK_code("if ($rmode == RTZ) {@ := 5;}", ret);
+  return ret;
+}
+
+int fesetround(int rm) 
+{
+  /*char *rmStr;
+  switch (rm) {
+  case FE_TONEARESTEVEN: rmStr = "RNE"; break;
+  case FE_TONEARESTAWAY: rmStr = "RNA"; break;
+  case FE_UPWARD: rmStr = "RTP"; break;
+  case FE_DOWNWARD: rmStr = "RTN"; break;
+  case FE_TOWARDZERO: rmStr = "RTZ";
+  }
+  __SMACK_code("$rmode := @;", rmStr);*/
+  switch (rm) {
+  case FE_TONEARESTEVEN: __SMACK_code("$rmode := RNE;"); break;
+  case FE_TONEARESTAWAY: __SMACK_code("$rmode := RNA;"); break;
+  case FE_UPWARD: __SMACK_code("$rmode := RTP;"); break;
+  case FE_DOWNWARD: __SMACK_code("$rmode := RTN;"); break;
+  case FE_TOWARDZERO: __SMACK_code("$rmode := RTZ;"); break;
+  }
+  return 0;
+}
+

--- a/share/smack/lib/math.c
+++ b/share/smack/lib/math.c
@@ -100,7 +100,7 @@ float fmodf(float x, float y) {
   y = fabsf(y);
   ret = remainderf(fabsf(x), y);
   if (__signbitf(ret)) {
-    __SMACK_code("@ := ftd($fadd.rm.bvfloat($rmode, dtf(@), dtr(@)));", ret, ret, y);
+    __SMACK_code("@ := ftd($fadd.rm.bvfloat($rmode, dtf(@), dtf(@)));", ret, ret, y);
   }
   return copysignf(ret, x);
 }

--- a/share/smack/lib/math.c
+++ b/share/smack/lib/math.c
@@ -20,55 +20,57 @@ float fdimf(float x, float y) {
     return nanf(0);
   }
   double val = __VERIFIER_nondet_double();
-  __SMACK_code("@ := ftd($fsub.bvfloat(dtf(@), dtf(@)));", val, x, y);
+  __SMACK_code("@ := ftd($fsub.rm.bvfloat($rmode, dtf(@), dtf(@)));", val, x, y);
   return fmaxf(0.0f, val);
 }
 
 float roundf(float x) {
   double ret = __VERIFIER_nondet_double();
-  __SMACK_code("@ := ftd($round.bvfloat(dtf(@)));", ret, x);
+  __SMACK_code("@ := ftd($round.rm.bvfloat(RNA, dtf(@)));", ret, x);
   return ret;
 }
 
 long lroundf(float x) {
-  long ret = __VERIFIER_nondet_long();
-  __SMACK_code("@ := $lround.bvfloat(dtf(@));", ret, x);
-  return ret;
+  return roundf(x);
 }
 
 float rintf(float x) {
-  return roundf(x);
+  double ret = __VERIFIER_nondet_double();
+  __SMACK_code("@ := ftd($round.rm.bvfloat($rmode, dtf(@)));", ret, x);
+  return ret;
 }
 
 float nearbyintf(float x) {
-  return roundf(x);
+  double ret = __VERIFIER_nondet_double();
+  __SMACK_code("@ := ftd($round.rm.bvfloat($rmode, dtf(@)));", ret, x);
+  return ret;
 }
 
 long lrintf(float x) {
-  return lroundf(x);
+  return rintf(x);
 }
 
 float floorf(float x) {
   double ret = __VERIFIER_nondet_double();
-  __SMACK_code("@ := ftd($floor.bvfloat(dtf(@)));", ret, x);
+  __SMACK_code("@ := ftd($round.rm.bvfloat(RTN, dtf(@)));", ret, x);
   return ret;
 }
 
 float ceilf(float x) {
   double ret = __VERIFIER_nondet_double();
-  __SMACK_code("@ := ftd($ceil.bvfloat(dtf(@)));", ret, x);
+  __SMACK_code("@ := ftd($round.rm.bvfloat(RTP, dtf(@)));", ret, x);
   return ret;
 }
 
 float truncf(float x) {
   double ret = __VERIFIER_nondet_double();
-  __SMACK_code("@ := ftd($trunc.bvfloat(dtf(@)));", ret, x);
+  __SMACK_code("@ := ftd($round.rm.bvfloat(RTZ, dtf(@)));", ret, x);
   return ret;
 }
 
 float sqrtf(float x) {
   double ret = __VERIFIER_nondet_double();
-  __SMACK_code("@ := ftd($sqrt.bvfloat(dtf(@)));", ret, x);
+  __SMACK_code("@ := ftd($sqrt.rm.bvfloat($rmode, dtf(@)));", ret, x);
   return ret;
 }
 
@@ -98,7 +100,7 @@ float fmodf(float x, float y) {
   y = fabsf(y);
   ret = remainderf(fabsf(x), y);
   if (__signbitf(ret)) {
-    __SMACK_code("@ := ftd($fadd.bvfloat(dtf(@), dtf(@)));", ret, ret, y);
+    __SMACK_code("@ := ftd($fadd.rm.bvfloat($rmode, dtf(@), dtr(@)));", ret, ret, y);
   }
   return copysignf(ret, x);
 }
@@ -111,7 +113,7 @@ float modff(float x, float *iPart) {
   } else {
     *iPart = truncf(x);
     fPart = __VERIFIER_nondet_double();
-    __SMACK_code("@ := ftd($fsub.bvdouble(dtf(@), dtf(@)));", fPart, x, *iPart);
+    __SMACK_code("@ := ftd($fsub.rm.bvdouble($rmode, dtf(@), dtf(@)));", fPart, x, *iPart);
   }
   if (__iszerof(fPart)) {
     fPart = __signbitf(x) ? -0.0f : 0.0f;
@@ -194,55 +196,57 @@ double fdim(double x, double y) {
     return nan(0);
   }
   double val = __VERIFIER_nondet_double();
-  __SMACK_code("@ := $fsub.bvdouble(@, @);", val, x, y);
+  __SMACK_code("@ := $fsub.rm.bvdouble($rmode, @, @);", val, x, y);
   return fmax(0.0, val);
 }
 
 double round(double x) {
   double ret = __VERIFIER_nondet_double();
-  __SMACK_code("@ := $round.bvdouble(@);", ret, x);
+  __SMACK_code("@ := $round.rm.bvdouble(RNA, @);", ret, x);
   return ret;
 }
 
 long lround(double x) {
-  long ret = __VERIFIER_nondet_long();
-  __SMACK_code("@ := $lround.bvdouble(@);", ret, x);
-  return ret;
+  return round(x);
 }
 
 double rint(double x) {
-  return round(x);
+  double ret = __VERIFIER_nondet_double();
+  __SMACK_code("@ := $round.rm.bvdouble($rmode, @);", ret, x);
+  return ret;
 }
 
 double nearbyint(double x) {
-  return round(x);
+  double ret = __VERIFIER_nondet_double();
+  __SMACK_code("@ := $round.rm.bvdouble($rmode, @);", ret, x);
+  return ret;
 }
 
 long lrint(double x) {
-  return lround(x);
+  return rint(x);
 }
 
 double floor(double x) {
   double ret = __VERIFIER_nondet_double();
-  __SMACK_code("@ := $floor.bvdouble(@);", ret, x);
+  __SMACK_code("@ := $round.rm.bvdouble(RTN, @);", ret, x);
   return ret;
 }
 
 double ceil(double x) {
   double ret = __VERIFIER_nondet_double();
-  __SMACK_code("@ := $ceil.bvdouble(@);", ret, x);
+  __SMACK_code("@ := $round.rm.bvdouble(RTP, @);", ret, x);
   return ret;
 }
 
 double trunc(double x) {
   double ret = __VERIFIER_nondet_double();
-  __SMACK_code("@ := $trunc.bvdouble(@);", ret, x);
+  __SMACK_code("@ := $round.rm.bvdouble(RTZ, @);", ret, x);
   return ret;
 }
 
 double sqrt(double x) {
   double ret = __VERIFIER_nondet_double();
-  __SMACK_code("@ := $sqrt.bvdouble(@);", ret, x);
+  __SMACK_code("@ := $sqrt.rm.bvdouble($rmode, @);", ret, x);
   return ret;
 }
 
@@ -272,7 +276,7 @@ double fmod(double x, double y) {
   y = fabs(y);
   ret = remainder(fabs(x), y);
   if (__signbit(ret)) {
-    __SMACK_code("@ := $fadd.bvdouble(@, @);", ret, ret, y);
+    __SMACK_code("@ := $fadd.rm.bvdouble($rmode, @, @);", ret, ret, y);
   }
   return copysign(ret, x);
 }
@@ -285,7 +289,7 @@ double modf(double x, double *iPart) {
   } else {
     *iPart = trunc(x);
     fPart = __VERIFIER_nondet_double();
-    __SMACK_code("@ := $fsub.bvdouble(@, @);", fPart, x, *iPart);
+    __SMACK_code("@ := $fsub.rm.bvdouble($rmode, @, @);", fPart, x, *iPart);
   }
   if (__iszero(fPart)) {
     fPart = (__signbit(x)) ? -0.0 : 0.0;

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -319,6 +319,7 @@ def build_libs(args):
 
   if args.float:
     libs += ['math.c']
+    libs += ['fenv.c']
 
   for c in map(lambda c: os.path.join(smack_lib(), c), libs):
     bc = temporary_file(os.path.splitext(os.path.basename(c))[0], '.bc', args)

--- a/test/mathc/fdim.c
+++ b/test/mathc/fdim.c
@@ -1,5 +1,5 @@
 #include "smack.h"
-#include "math.h"
+#include <math.h>
 #include <stdio.h>
 
 // @expect verified

--- a/test/mathc/fdimf.c
+++ b/test/mathc/fdimf.c
@@ -1,5 +1,5 @@
 #include "smack.h"
-#include "math.h"
+#include <math.h>
 #include <stdio.h>
 
 // @expect verified

--- a/test/mathc/issue_198.c
+++ b/test/mathc/issue_198.c
@@ -1,4 +1,4 @@
-#include <smack.h>
+#include smack.h"
 #include <math.h>
 
 // @expect verified

--- a/test/mathc/lrint.c
+++ b/test/mathc/lrint.c
@@ -1,0 +1,52 @@
+#include "smack.h"
+#include <math.h>
+#include <fenv.h>
+
+// @expect verified
+
+int main(void) {
+  double NaN = 0.0 / 0.0;
+  double Inf = 1.0 / 0.0;
+  double negInf = -1.0 / 0.0;
+
+  double a = -2.5;
+  double b = -2.4999999999;
+  double c = -2.5000000001;
+  double d = 8.3;
+
+  fesetround(FE_TONEARESTEVEN);
+  assert(lrint(a) == -2);
+  assert(lrint(b) == -2);
+  assert(lrint(c) == -3);
+  assert(lrint(d) == 8);
+
+  fesetround(FE_TONEARESTAWAY);
+  assert(lrint(a) == -3);
+  assert(lrint(b) == -2);
+  assert(lrint(c) == -3);
+  assert(lrint(d) == 8);
+
+  fesetround(FE_UPWARD);
+  assert(lrint(a) == -2);
+  assert(lrint(b) == -2);
+  assert(lrint(c) == -2);
+  assert(lrint(d) == 9);
+
+  fesetround(FE_DOWNWARD);
+  assert(lrint(a) == -3);
+  assert(lrint(b) == -3);
+  assert(lrint(c) == -3);
+  assert(lrint(d) == 8);
+
+  fesetround(FE_TOWARDZERO);
+  assert(lrint(a) == -2);
+  assert(lrint(b) == -2);
+  assert(lrint(c) == -2);
+  assert(lrint(d) == 8);
+
+  assert(lrint(0.0) == 0);
+  assert(lrint(-0.0) == 0);
+
+  return 0;
+}
+

--- a/test/mathc/lrintf.c
+++ b/test/mathc/lrintf.c
@@ -1,0 +1,52 @@
+#include "smack.h"
+#include <math.h>
+#include <fenv.h>
+
+// @expect verified
+
+int main(void) {
+  float NaN = 0.0f / 0.0f;
+  float Inf = 1.0f / 0.0f;
+  float negInf = -1.0f / 0.0f;
+
+  float a = -2.5f;
+  float b = -2.4999999999f;
+  float c = -2.5000000001f;
+  float d = 8.3f;
+
+  fesetround(FE_TONEARESTEVEN);
+  assert(lrintf(a) == -2);
+  assert(lrintf(b) == -2);
+  assert(lrintf(c) == -3);
+  assert(lrintf(d) == 8);
+
+  fesetround(FE_TONEARESTAWAY);
+  assert(lrintf(a) == -3);
+  assert(lrintf(b) == -2);
+  assert(lrintf(c) == -3);
+  assert(lrintf(d) == 8);
+
+  fesetround(FE_UPWARD);
+  assert(lrintf(a) == -2);
+  assert(lrintf(b) == -2);
+  assert(lrintf(c) == -2);
+  assert(lrintf(d) == 9);
+
+  fesetround(FE_DOWNWARD);
+  assert(lrintf(a) == -3);
+  assert(lrintf(b) == -3);
+  assert(lrintf(c) == -3);
+  assert(lrintf(d) == 8);
+
+  fesetround(FE_TOWARDZERO);
+  assert(lrintf(a) == -2);
+  assert(lrintf(b) == -2);
+  assert(lrintf(c) == -2);
+  assert(lrintf(d) == 8);
+
+  assert(lrintf(0.0f) == 0);
+  assert(lrintf(-0.0f) == 0);
+
+  return 0;
+}
+

--- a/test/mathc/lround.c
+++ b/test/mathc/lround.c
@@ -1,0 +1,28 @@
+#include "smack.h"
+#include <math.h>
+
+// @expect verified
+
+int main(void) {
+  double NaN = 0.0 / 0.0;
+  double Inf = 1.0 / 0.0;
+  double negInf = -1.0 / 0.0;
+  
+  double a = -1.5;
+  double b = -1.49999999999999999;
+  double c = 3.5;
+  double d = 2.0;
+
+  assert(lround(a) == -2);
+  assert(lround(b) == -1);
+  assert(lround(c) == 4);
+  assert(lround(d) == 2);
+
+  assert(lround(0.0) == 0);
+  assert(lround(-0.0) == 0);
+  int isNeg = __signbit(lround(-0.0));
+  assert(isNeg);
+
+  return 0;
+}
+

--- a/test/mathc/lroundf.c
+++ b/test/mathc/lroundf.c
@@ -1,0 +1,28 @@
+#include "smack.h"
+#include <math.h>
+
+// @expect verified
+
+int main(void) {
+  float NaN = 0.0f / 0.0f;
+  float Inf = 1.0f / 0.0f;
+  float negInf = -1.0f / 0.0f;
+  
+  float a = -1.5f;
+  float b = -1.49999999999999999f;
+  float c = 3.5f;
+  float d = 2.0f;
+
+  assert(lroundf(a) == -2);
+  assert(lroundf(b) == -1);
+  assert(lroundf(c) == 4);
+  assert(lroundf(d) == 2);
+
+  assert(lroundf(0.0f) == 0);
+  assert(lroundf(-0.0f) == 0);
+  int isNeg = __signbitf(lroundf(-0.0f));
+  assert(isNeg);
+
+  return 0;
+}
+

--- a/test/mathc/modf.c
+++ b/test/mathc/modf.c
@@ -1,5 +1,5 @@
 #include "smack.h"
-#include "math.h"
+#include <math.h>
 #include <stdio.h>
 
 // @expect verified

--- a/test/mathc/modff.c
+++ b/test/mathc/modff.c
@@ -1,5 +1,5 @@
 #include "smack.h"
-#include "math.h"
+#include <math.h>
 #include <stdio.h>
 
 // @expect verified

--- a/test/mathc/nearbyint.c
+++ b/test/mathc/nearbyint.c
@@ -1,6 +1,6 @@
 #include "smack.h"
 #include <math.h>
-#include "fenv.h"
+#include <fenv.h>
 
 // @expect verified
 

--- a/test/mathc/nearbyint.c
+++ b/test/mathc/nearbyint.c
@@ -1,0 +1,59 @@
+#include "smack.h"
+#include <math.h>
+#include "fenv.h"
+
+// @expect verified
+
+int main(void) {
+  double NaN = 0.0 / 0.0;
+  double Inf = 1.0 / 0.0;
+  double negInf = -1.0 / 0.0;
+
+  double a = -3.5;
+  double b = -3.4999999999;
+  double c = -3.5000000001;
+  double d = 7.3;
+
+  fesetround(FE_TONEARESTEVEN);
+  assert(nearbyint(a) == -4.0);
+  assert(nearbyint(b) == -3.0);
+  assert(nearbyint(c) == -4.0);
+  assert(nearbyint(d) == 7.0);
+
+  fesetround(FE_TONEARESTAWAY);
+  assert(nearbyint(a) == -4.0);
+  assert(nearbyint(b) == -3.0);
+  assert(nearbyint(c) == -4.0);
+  assert(nearbyint(d) == 7.0);
+
+  fesetround(FE_UPWARD);
+  assert(nearbyint(a) == -3.0);
+  assert(nearbyint(b) == -3.0);
+  assert(nearbyint(c) == -3.0);
+  assert(nearbyint(d) == 8.0);
+
+  fesetround(FE_DOWNWARD);
+  assert(nearbyint(a) == -4.0);
+  assert(nearbyint(b) == -4.0);
+  assert(nearbyint(c) == -4.0);
+  assert(nearbyint(d) == 7.0);
+
+  fesetround(FE_TOWARDZERO);
+  assert(nearbyint(a) == -3.0);
+  assert(nearbyint(b) == -3.0);
+  assert(nearbyint(c) == -3.0);
+  assert(nearbyint(d) == 7.0);
+
+  assert(nearbyint(0.0) == 0.0);
+  assert(nearbyint(-0.0) == -0.0);
+  int isNeg = __signbit(nearbyint(-0.0));
+  assert(isNeg);
+
+  assert(nearbyint(Inf) == Inf);
+  assert(nearbyint(negInf) == negInf);
+
+  assert(__isnan(nearbyint(NaN)));
+
+  return 0;
+}
+

--- a/test/mathc/nearbyintf.c
+++ b/test/mathc/nearbyintf.c
@@ -1,6 +1,6 @@
 #include "smack.h"
 #include <math.h>
-#include "fenv.h"
+#include <fenv.h>
 
 // @expect verified
 

--- a/test/mathc/nearbyintf.c
+++ b/test/mathc/nearbyintf.c
@@ -1,0 +1,59 @@
+#include "smack.h"
+#include <math.h>
+#include "fenv.h"
+
+// @expect verified
+
+int main(void) {
+  float NaN = 0.0f / 0.0f;
+  float Inf = 1.0f / 0.0f;
+  float negInf = -1.0f / 0.0f;
+
+  float a = -3.5f;
+  float b = -3.4999999999f;
+  float c = -3.5000000001f;
+  float d = 7.3f;
+
+  fesetround(FE_TONEARESTEVEN);
+  assert(nearbyintf(a) == -4.0f);
+  assert(nearbyintf(b) == -3.0f);
+  assert(nearbyintf(c) == -4.0f);
+  assert(nearbyintf(d) == 7.0f);
+
+  fesetround(FE_TONEARESTAWAY);
+  assert(nearbyintf(a) == -4.0f);
+  assert(nearbyintf(b) == -3.0f);
+  assert(nearbyintf(c) == -4.0f);
+  assert(nearbyintf(d) == 7.0f);
+
+  fesetround(FE_UPWARD);
+  assert(nearbyintf(a) == -3.0f);
+  assert(nearbyintf(b) == -3.0f);
+  assert(nearbyintf(c) == -3.0f);
+  assert(nearbyintf(d) == 8.0f);
+
+  fesetround(FE_DOWNWARD);
+  assert(nearbyintf(a) == -4.0f);
+  assert(nearbyintf(b) == -4.0f);
+  assert(nearbyintf(c) == -4.0f);
+  assert(nearbyintf(d) == 7.0f);
+
+  fesetround(FE_TOWARDZERO);
+  assert(nearbyintf(a) == -3.0f);
+  assert(nearbyintf(b) == -3.0f);
+  assert(nearbyintf(c) == -3.0f);
+  assert(nearbyintf(d) == 7.0f);
+
+  assert(nearbyintf(0.0f) == 0.0f);
+  assert(nearbyintf(-0.0f) == -0.0f);
+  int isNeg = __signbitf(nearbyintf(-0.0f));
+  assert(isNeg);
+
+  assert(nearbyintf(Inf) == Inf);
+  assert(nearbyintf(negInf) == negInf);
+
+  assert(__isnanf(nearbyintf(NaN)));
+
+  return 0;
+}
+

--- a/test/mathc/rint.c
+++ b/test/mathc/rint.c
@@ -1,6 +1,6 @@
 #include "smack.h"
 #include <math.h>
-#include "fenv.h"
+#include <fenv.h>
 
 // @expect verified
 

--- a/test/mathc/rint.c
+++ b/test/mathc/rint.c
@@ -1,0 +1,59 @@
+#include "smack.h"
+#include <math.h>
+#include "fenv.h"
+
+// @expect verified
+
+int main(void) {
+  double NaN = 0.0 / 0.0;
+  double Inf = 1.0 / 0.0;
+  double negInf = -1.0 / 0.0;
+
+  double a = -4.5;
+  double b = -4.4999999999;
+  double c = -4.5000000001;
+  double d = 5.3;
+
+  fesetround(FE_TONEARESTEVEN);
+  assert(rint(a) == -4.0);
+  assert(rint(b) == -4.0);
+  assert(rint(c) == -5.0);
+  assert(rint(d) == 5.0);
+
+  fesetround(FE_TONEARESTAWAY);
+  assert(rint(a) == -5.0);
+  assert(rint(b) == -4.0);
+  assert(rint(c) == -5.0);
+  assert(rint(d) == 5.0);
+
+  fesetround(FE_UPWARD);
+  assert(rint(a) == -4.0);
+  assert(rint(b) == -4.0);
+  assert(rint(c) == -4.0);
+  assert(rint(d) == 6.0);
+
+  fesetround(FE_DOWNWARD);
+  assert(rint(a) == -5.0);
+  assert(rint(b) == -5.0);
+  assert(rint(c) == -5.0);
+  assert(rint(d) == 5.0);
+
+  fesetround(FE_TOWARDZERO);
+  assert(rint(a) == -4.0);
+  assert(rint(b) == -4.0);
+  assert(rint(c) == -4.0);
+  assert(rint(d) == 5.0);
+
+  assert(rint(0.0) == 0.0);
+  assert(rint(-0.0) == -0.0);
+  int isNeg = __signbit(rint(-0.0));
+  assert(isNeg);
+
+  assert(rint(Inf) == Inf);
+  assert(rint(negInf) == negInf);
+
+  assert(__isnan(rint(NaN)));
+
+  return 0;
+}
+

--- a/test/mathc/rintf.c
+++ b/test/mathc/rintf.c
@@ -1,6 +1,6 @@
 #include "smack.h"
 #include <math.h>
-#include "fenv.h"
+#include <fenv.h>
 
 // @expect verified
 

--- a/test/mathc/rintf.c
+++ b/test/mathc/rintf.c
@@ -1,0 +1,59 @@
+#include "smack.h"
+#include <math.h>
+#include "fenv.h"
+
+// @expect verified
+
+int main(void) {
+  float NaN = 0.0f / 0.0f;
+  float Inf = 1.0f / 0.0f;
+  float negInf = -1.0f / 0.0f;
+
+  float a = -4.5f;
+  float b = -4.4999999999f;
+  float c = -4.5000000001f;
+  float d = 5.3f;
+
+  fesetround(FE_TONEARESTEVEN);
+  assert(rintf(a) == -4.0f);
+  assert(rintf(b) == -4.0f);
+  assert(rintf(c) == -5.0f);
+  assert(rintf(d) == 5.0f);
+
+  fesetround(FE_TONEARESTAWAY);
+  assert(rintf(a) == -5.0f);
+  assert(rintf(b) == -4.0f);
+  assert(rintf(c) == -5.0f);
+  assert(rintf(d) == 5.0f);
+
+  fesetround(FE_UPWARD);
+  assert(rintf(a) == -4.0f);
+  assert(rintf(b) == -4.0f);
+  assert(rintf(c) == -4.0f);
+  assert(rintf(d) == 6.0f);
+
+  fesetround(FE_DOWNWARD);
+  assert(rintf(a) == -5.0f);
+  assert(rintf(b) == -5.0f);
+  assert(rintf(c) == -5.0f);
+  assert(rintf(d) == 5.0f);
+
+  fesetround(FE_TOWARDZERO);
+  assert(rintf(a) == -4.0f);
+  assert(rintf(b) == -4.0f);
+  assert(rintf(c) == -4.0f);
+  assert(rintf(d) == 5.0f);
+
+  assert(rintf(0.0f) == 0.0f);
+  assert(rintf(-0.0f) == -0.0f);
+  int isNeg = __signbitf(rintf(-0.0f));
+  assert(isNeg);
+
+  assert(rintf(Inf) == Inf);
+  assert(rintf(negInf) == negInf);
+
+  assert(__isnanf(rintf(NaN)));
+
+  return 0;
+}
+


### PR DESCRIPTION
This adds the following:
-Support for Boogie's "rmode" type
-Support for the fegetround() and fesetround() functions in fenv.h
-Support for the lround(), lrint(), rint(), and nearbyint() functions in math.h
-Regressions for the above four functions
-Support for other functions in math.h to handle changes in the rounding mode