### PR TITLE
Make escape characters more robust

### DIFF
--- a/lib/smack/Naming.cpp
+++ b/lib/smack/Naming.cpp
@@ -191,6 +191,7 @@ std::string Naming::escape(std::string s) {
     case '{': case '}':
     case '<': case '>':
     case '|': case '"':
+    case '-':
       Str[i] = '_';
       break;
     // Another character to escape would be '$', but SMACK internally

--- a/lib/smack/Naming.cpp
+++ b/lib/smack/Naming.cpp
@@ -178,16 +178,34 @@ bool Naming::isSmackGeneratedName(std::string n) {
 }
 
 std::string Naming::escape(std::string s) {
-  std::string Str(llvm::DOT::EscapeString(s));
+  std::string Str(s);
   for (unsigned i = 0; i != Str.length(); ++i)
     switch (Str[i]) {
-    case '\01':
-      Str[i] = '_';
-      break;
+    // Special boogie characters
     case '@':
       Str[i] = '.';
       break;
-    case ':':
+    case '\01': case '\\':
+    case '$': case ':':
+    case '(': case ')':
+    case '[': case ']':
+      Str[i] = '_';
+      break;
+    
+    // Reproduce behavior of llvm::DOT::EscapeString without backslashes
+    case '\n':
+      Str.insert(Str.begin()+i, '_');  // convert '\n' to "_n"
+      ++i;
+      Str[i] = 'n';
+      break;
+    case '\t':
+      Str.insert(Str.begin()+i, ' ');  // Convert to two spaces
+      ++i;
+      Str[i] = ' ';
+      break;
+    case '{': case '}':
+    case '<': case '>':
+    case '|': case '"':
       Str[i] = '_';
       break;
     }

--- a/lib/smack/Naming.cpp
+++ b/lib/smack/Naming.cpp
@@ -186,7 +186,7 @@ std::string Naming::escape(std::string s) {
       Str[i] = '.';
       break;
     case '\01': case '\\':
-    case ':':
+    case ':': case ' ':
     case '(': case ')':
     case '[': case ']':
       Str[i] = '_';
@@ -195,16 +195,6 @@ std::string Naming::escape(std::string s) {
     // generates LLVM IR that uses this character.
     
     // Reproduce behavior of llvm::DOT::EscapeString without backslashes
-    case '\n':
-      Str.insert(Str.begin()+i, '_');  // convert '\n' to "_n"
-      ++i;
-      Str[i] = 'n';
-      break;
-    case '\t':
-      Str.insert(Str.begin()+i, ' ');  // Convert to two spaces
-      ++i;
-      Str[i] = ' ';
-      break;
     case '{': case '}':
     case '<': case '>':
     case '|': case '"':

--- a/lib/smack/Naming.cpp
+++ b/lib/smack/Naming.cpp
@@ -181,7 +181,6 @@ std::string Naming::escape(std::string s) {
   std::string Str(s);
   for (unsigned i = 0; i != Str.length(); ++i)
     switch (Str[i]) {
-    // Special boogie characters
     case '@':
       Str[i] = '.';
       break;
@@ -189,17 +188,13 @@ std::string Naming::escape(std::string s) {
     case ':': case ' ':
     case '(': case ')':
     case '[': case ']':
-      Str[i] = '_';
-      break;
-    // Another character to escape would be '$', but SMACK internally
-    // generates LLVM IR that uses this character.
-    
-    // Reproduce behavior of llvm::DOT::EscapeString without backslashes
     case '{': case '}':
     case '<': case '>':
     case '|': case '"':
       Str[i] = '_';
       break;
+    // Another character to escape would be '$', but SMACK internally
+    // generates LLVM IR that uses this character.
     }
   return Str;
 }

--- a/lib/smack/Naming.cpp
+++ b/lib/smack/Naming.cpp
@@ -186,11 +186,13 @@ std::string Naming::escape(std::string s) {
       Str[i] = '.';
       break;
     case '\01': case '\\':
-    case '$': case ':':
+    case ':':
     case '(': case ')':
     case '[': case ']':
       Str[i] = '_';
       break;
+    // Another character to escape would be '$', but SMACK internally
+    // generates LLVM IR that uses this character.
     
     // Reproduce behavior of llvm::DOT::EscapeString without backslashes
     case '\n':


### PR DESCRIPTION
Extend Naming::escape's functionality
to escape many more characters.

Because Boogie can't handle backslashes in
identifiers, the call to llvm::DOT::EscapeString
has been removed. All of the characters that this
method currently escapes have been added to
Naming::escape

Most characters are replaced with underscores.
Theoretically, this could cause naming conflicts
in the future, but the probablity of two names
being identical except for their special characters
is low enough that it's worth it to neglect that
possibility right now.

Fixes #323 