### PR TITLE
Changed definition of rounding modes

### DIFF
--- a/share/smack/include/fenv.h
+++ b/share/smack/include/fenv.h
@@ -4,11 +4,10 @@
 #ifndef FENV_H
 #define FENV_H
 
-#define FE_TONEARESTEVEN 1
-#define FE_TONEARESTAWAY 2
-#define FE_UPWARD 3
-#define FE_DOWNWARD 4
-#define FE_TOWARDZERO 5
+#define FE_TONEAREST 0
+#define FE_DOWNWARD 0x400
+#define FE_UPWARD 0x800
+#define FE_TOWARDZERO 0xc00
 
 int fegetround(void);
 int fesetround(int);

--- a/share/smack/lib/fenv.c
+++ b/share/smack/lib/fenv.c
@@ -6,20 +6,18 @@
 int fegetround(void) {
   int ret = __VERIFIER_nondet_int();
   assume(ret < 0);
-  __SMACK_code("if ($rmode == RNE) {@ := 1;}", ret);
-  __SMACK_code("if ($rmode == RNA) {@ := 2;}", ret);
-  __SMACK_code("if ($rmode == RTP) {@ := 3;}", ret);
-  __SMACK_code("if ($rmode == RTN) {@ := 4;}", ret);
-  __SMACK_code("if ($rmode == RTZ) {@ := 5;}", ret);
+  __SMACK_code("if ($rmode == RNE) {@ := 0;}", ret);
+  __SMACK_code("if ($rmode == RTN) {@ := 1024;}", ret);
+  __SMACK_code("if ($rmode == RTP) {@ := 2048;}", ret);
+  __SMACK_code("if ($rmode == RTZ) {@ := 3072;}", ret);
   return ret;
 }
 
 int fesetround(int rm) {
   switch (rm) {
-  case FE_TONEARESTEVEN: __SMACK_code("$rmode := RNE;"); break;
-  case FE_TONEARESTAWAY: __SMACK_code("$rmode := RNA;"); break;
-  case FE_UPWARD: __SMACK_code("$rmode := RTP;"); break;
+  case FE_TONEAREST: __SMACK_code("$rmode := RNE;"); break;
   case FE_DOWNWARD: __SMACK_code("$rmode := RTN;"); break;
+  case FE_UPWARD: __SMACK_code("$rmode := RTP;"); break;
   case FE_TOWARDZERO: __SMACK_code("$rmode := RTZ;"); break;
   default: return 1;
   }

--- a/test/float/change_rm.c
+++ b/test/float/change_rm.c
@@ -4,10 +4,10 @@
 // @expect verified
 
 int main(void) {
-  assert(fegetround() == FE_TONEARESTEVEN);
+  assert(fegetround() == FE_TONEAREST);
 
   int rm = __VERIFIER_nondet_int();
-  assume(rm >= 1 && rm <= 5);
+  assume(rm == FE_TONEAREST || rm == FE_DOWNWARD || rm == FE_UPWARD || rm == FE_TOWARDZERO);
   
   assert(!fesetround(rm));
 

--- a/test/float/get_rm_invalid.c
+++ b/test/float/get_rm_invalid.c
@@ -5,7 +5,7 @@
 
 int main(void) {
   int rm = fegetround();
-  assume(rm < 1 || rm > 5);
+  assume(rm != FE_TONEAREST && rm != FE_DOWNWARD && rm != FE_UPWARD && rm != FE_TOWARDZERO);
 
   assert(rm < 0);
 

--- a/test/float/get_rm_invalid_fail.c
+++ b/test/float/get_rm_invalid_fail.c
@@ -5,7 +5,7 @@
 
 int main(void) {
   int rm = fegetround();
-  assume(rm <= 1 || rm > 5);
+  assume(rm != FE_DOWNWARD && rm != FE_UPWARD && rm != FE_TOWARDZERO);
 
   assert(rm < 0);
 

--- a/test/float/set_rm_invalid.c
+++ b/test/float/set_rm_invalid.c
@@ -5,7 +5,7 @@
 
 int main(void) {
   int rm = __VERIFIER_nondet_int();
-  assume(rm < 1 || rm > 5);
+  assume(rm != FE_TONEAREST && rm != FE_DOWNWARD && rm != FE_UPWARD && rm != FE_TOWARDZERO);
 
   assert(fesetround(rm));
 

--- a/test/float/set_rm_invalid_fail.c
+++ b/test/float/set_rm_invalid_fail.c
@@ -5,7 +5,7 @@
 
 int main(void) {
   int rm = __VERIFIER_nondet_int();
-  assume(rm < 1 || rm >= 5);
+  assume(rm != FE_TONEAREST && rm != FE_DOWNWARD && rm != FE_UPWARD);
 
   assert(fesetround(rm));
 

--- a/test/mathc/lrint.c
+++ b/test/mathc/lrint.c
@@ -14,14 +14,8 @@ int main(void) {
   double c = -2.5000000001;
   double d = 8.3;
 
-  fesetround(FE_TONEARESTEVEN);
+  fesetround(FE_TONEAREST);
   assert(lrint(a) == -2);
-  assert(lrint(b) == -2);
-  assert(lrint(c) == -3);
-  assert(lrint(d) == 8);
-
-  fesetround(FE_TONEARESTAWAY);
-  assert(lrint(a) == -3);
   assert(lrint(b) == -2);
   assert(lrint(c) == -3);
   assert(lrint(d) == 8);

--- a/test/mathc/lrint_fail.c
+++ b/test/mathc/lrint_fail.c
@@ -14,14 +14,8 @@ int main(void) {
   double c = -2.5000000001;
   double d = 8.3;
 
-  fesetround(FE_TONEARESTEVEN);
+  fesetround(FE_TONEAREST);
   assert(lrint(a) == 2);
-  assert(lrint(b) == -2);
-  assert(lrint(c) == -3);
-  assert(lrint(d) == 8);
-
-  fesetround(FE_TONEARESTAWAY);
-  assert(lrint(a) == -3);
   assert(lrint(b) == -2);
   assert(lrint(c) == -3);
   assert(lrint(d) == 8);

--- a/test/mathc/lrintf.c
+++ b/test/mathc/lrintf.c
@@ -14,14 +14,8 @@ int main(void) {
   float c = -2.5000000001f;
   float d = 8.3f;
 
-  fesetround(FE_TONEARESTEVEN);
+  fesetround(FE_TONEAREST);
   assert(lrintf(a) == -2);
-  assert(lrintf(b) == -2);
-  assert(lrintf(c) == -3);
-  assert(lrintf(d) == 8);
-
-  fesetround(FE_TONEARESTAWAY);
-  assert(lrintf(a) == -3);
   assert(lrintf(b) == -2);
   assert(lrintf(c) == -3);
   assert(lrintf(d) == 8);

--- a/test/mathc/lrintf_fail.c
+++ b/test/mathc/lrintf_fail.c
@@ -14,21 +14,15 @@ int main(void) {
   float c = -2.5000000001f;
   float d = 8.3f;
 
-  fesetround(FE_TONEARESTEVEN);
+  fesetround(FE_TONEAREST);
   assert(lrintf(a) == -2);
   assert(lrintf(b) == -2);
-  assert(lrintf(c) == -3);
-  assert(lrintf(d) == 8);
-
-  fesetround(FE_TONEARESTAWAY);
-  assert(lrintf(a) == -3);
-  assert(lrintf(b) == 2);
   assert(lrintf(c) == -3);
   assert(lrintf(d) == 8);
 
   fesetround(FE_UPWARD);
   assert(lrintf(a) == -2);
-  assert(lrintf(b) == -2);
+  assert(lrintf(b) == -1);
   assert(lrintf(c) == -2);
   assert(lrintf(d) == 9);
 

--- a/test/mathc/nearbyint.c
+++ b/test/mathc/nearbyint.c
@@ -14,13 +14,7 @@ int main(void) {
   double c = -3.5000000001;
   double d = 7.3;
 
-  fesetround(FE_TONEARESTEVEN);
-  assert(nearbyint(a) == -4.0);
-  assert(nearbyint(b) == -3.0);
-  assert(nearbyint(c) == -4.0);
-  assert(nearbyint(d) == 7.0);
-
-  fesetround(FE_TONEARESTAWAY);
+  fesetround(FE_TONEAREST);
   assert(nearbyint(a) == -4.0);
   assert(nearbyint(b) == -3.0);
   assert(nearbyint(c) == -4.0);

--- a/test/mathc/nearbyint_fail.c
+++ b/test/mathc/nearbyint_fail.c
@@ -14,14 +14,8 @@ int main(void) {
   double c = -3.5000000001;
   double d = 7.3;
 
-  fesetround(FE_TONEARESTEVEN);
-  assert(nearbyint(a) == 4.0);
-  assert(nearbyint(b) == -3.0);
-  assert(nearbyint(c) == -4.0);
-  assert(nearbyint(d) == 7.0);
-
-  fesetround(FE_TONEARESTAWAY);
-  assert(nearbyint(a) == -4.0);
+  fesetround(FE_TONEAREST);
+  assert(nearbyint(a) == -3.0);
   assert(nearbyint(b) == -3.0);
   assert(nearbyint(c) == -4.0);
   assert(nearbyint(d) == 7.0);

--- a/test/mathc/nearbyintf.c
+++ b/test/mathc/nearbyintf.c
@@ -14,13 +14,7 @@ int main(void) {
   float c = -3.5000000001f;
   float d = 7.3f;
 
-  fesetround(FE_TONEARESTEVEN);
-  assert(nearbyintf(a) == -4.0f);
-  assert(nearbyintf(b) == -3.0f);
-  assert(nearbyintf(c) == -4.0f);
-  assert(nearbyintf(d) == 7.0f);
-
-  fesetround(FE_TONEARESTAWAY);
+  fesetround(FE_TONEAREST);
   assert(nearbyintf(a) == -4.0f);
   assert(nearbyintf(b) == -3.0f);
   assert(nearbyintf(c) == -4.0f);

--- a/test/mathc/nearbyintf_fail.c
+++ b/test/mathc/nearbyintf_fail.c
@@ -14,21 +14,15 @@ int main(void) {
   float c = -3.5000000001f;
   float d = 7.3f;
 
-  fesetround(FE_TONEARESTEVEN);
+  fesetround(FE_TONEAREST);
   assert(nearbyintf(a) == -4.0f);
   assert(nearbyintf(b) == -3.0f);
-  assert(nearbyintf(c) == -4.0f);
-  assert(nearbyintf(d) == 7.0f);
-
-  fesetround(FE_TONEARESTAWAY);
-  assert(nearbyintf(a) == -4.0f);
-  assert(nearbyintf(b) == 3.0f);
   assert(nearbyintf(c) == -4.0f);
   assert(nearbyintf(d) == 7.0f);
 
   fesetround(FE_UPWARD);
   assert(nearbyintf(a) == -3.0f);
-  assert(nearbyintf(b) == -3.0f);
+  assert(nearbyintf(b) == -2.0f);
   assert(nearbyintf(c) == -3.0f);
   assert(nearbyintf(d) == 8.0f);
 

--- a/test/mathc/rint.c
+++ b/test/mathc/rint.c
@@ -14,14 +14,8 @@ int main(void) {
   double c = -4.5000000001;
   double d = 5.3;
 
-  fesetround(FE_TONEARESTEVEN);
+  fesetround(FE_TONEAREST);
   assert(rint(a) == -4.0);
-  assert(rint(b) == -4.0);
-  assert(rint(c) == -5.0);
-  assert(rint(d) == 5.0);
-
-  fesetround(FE_TONEARESTAWAY);
-  assert(rint(a) == -5.0);
   assert(rint(b) == -4.0);
   assert(rint(c) == -5.0);
   assert(rint(d) == 5.0);

--- a/test/mathc/rint_fail.c
+++ b/test/mathc/rint_fail.c
@@ -14,14 +14,8 @@ int main(void) {
   double c = -4.5000000001;
   double d = 5.3;
 
-  fesetround(FE_TONEARESTEVEN);
+  fesetround(FE_TONEAREST);
   assert(rint(a) == 4.0);
-  assert(rint(b) == -4.0);
-  assert(rint(c) == -5.0);
-  assert(rint(d) == 5.0);
-
-  fesetround(FE_TONEARESTAWAY);
-  assert(rint(a) == -5.0);
   assert(rint(b) == -4.0);
   assert(rint(c) == -5.0);
   assert(rint(d) == 5.0);

--- a/test/mathc/rintf.c
+++ b/test/mathc/rintf.c
@@ -14,14 +14,8 @@ int main(void) {
   float c = -4.5000000001f;
   float d = 5.3f;
 
-  fesetround(FE_TONEARESTEVEN);
+  fesetround(FE_TONEAREST);
   assert(rintf(a) == -4.0f);
-  assert(rintf(b) == -4.0f);
-  assert(rintf(c) == -5.0f);
-  assert(rintf(d) == 5.0f);
-
-  fesetround(FE_TONEARESTAWAY);
-  assert(rintf(a) == -5.0f);
   assert(rintf(b) == -4.0f);
   assert(rintf(c) == -5.0f);
   assert(rintf(d) == 5.0f);

--- a/test/mathc/rintf_fail.c
+++ b/test/mathc/rintf_fail.c
@@ -14,21 +14,15 @@ int main(void) {
   float c = -4.5000000001f;
   float d = 5.3f;
 
-  fesetround(FE_TONEARESTEVEN);
+  fesetround(FE_TONEAREST);
   assert(rintf(a) == -4.0f);
   assert(rintf(b) == -4.0f);
-  assert(rintf(c) == -5.0f);
-  assert(rintf(d) == 5.0f);
-
-  fesetround(FE_TONEARESTAWAY);
-  assert(rintf(a) == -5.0f);
-  assert(rintf(b) == 4.0f);
   assert(rintf(c) == -5.0f);
   assert(rintf(d) == 5.0f);
 
   fesetround(FE_UPWARD);
   assert(rintf(a) == -4.0f);
-  assert(rintf(b) == -4.0f);
+  assert(rintf(b) == -3.0f);
   assert(rintf(c) == -4.0f);
   assert(rintf(d) == 6.0f);
 


### PR DESCRIPTION
This pull request:
-Redefines rounding mode macros to have values more consistent with
those used by other implementations
-Combines FE_TONEARESTEVEN and FE_TONEARESTAWAY into FE_TONEAREST in
order to conform to the C standard