### PR TITLE
Fixed fp2si and fp2ui function arguments

### DIFF
--- a/lib/smack/SmackRep.cpp
+++ b/lib/smack/SmackRep.cpp
@@ -821,9 +821,11 @@ const Expr* SmackRep::cast(const llvm::ConstantExpr* CE) {
 
 const Expr* SmackRep::cast(unsigned opcode, const llvm::Value* v, const llvm::Type* t) {
   std::string fn = Naming::INSTRUCTION_TABLE.at(opcode);
-  if (opcode == Instruction::FPTrunc || opcode == Instruction::FPExt || opcode == Instruction::SIToFP
-    || opcode == Instruction::UIToFP || opcode == Instruction::FPToSI || opcode == Instruction::FPToUI) {
+  if (opcode == Instruction::FPTrunc || opcode == Instruction::FPExt
+    || opcode == Instruction::SIToFP || opcode == Instruction::UIToFP) {
     return Expr::fn(opName(fn, {v->getType(), t}), Expr::id(Naming::RMODE_VAR), expr(v));
+  } else if (opcode == Instruction::FPToSI || opcode == Instruction::FPToUI) {
+    return Expr::fn(opName(fn, {v->getType(), t}), Expr::lit(RModeKind::RTZ), expr(v));
   }
   return Expr::fn(opName(fn, {v->getType(), t}), expr(v));
 }

--- a/test/float/double_to_int.c
+++ b/test/float/double_to_int.c
@@ -1,0 +1,11 @@
+#include "smack.h"
+
+// @flag --bit-precise
+// @expect verified
+
+int main(void) {
+  double x = 1.5;
+  int y = x;
+
+  assert(y == 1);
+}

--- a/test/float/double_to_int_fail.c
+++ b/test/float/double_to_int_fail.c
@@ -1,0 +1,11 @@
+#include "smack.h"
+
+// @flag --bit-precise
+// @expect error
+
+int main(void) {
+  double x = 1.5;
+  int y = x;
+
+  assert(y == 2);
+}


### PR DESCRIPTION
This changes fp2si and fp2ui to always use RTZ as the rounding mode so that
casting from floating-point types to integer types is modeled correctly.