### PR TITLE
Colorize Clang's output

### DIFF
--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -310,6 +310,7 @@ def default_clang_compile_command(args, lib = False):
   if args.memory_safety: cmd += ['-DMEMORY_SAFETY']
   if args.integer_overflow: cmd += (['-ftrapv'] if not lib else ['-DSIGNED_INTEGER_OVERFLOW_CHECK'])
   if args.float: cmd += ['-DFLOAT_ENABLED']
+  if sys.stdout.isatty(): cmd += ['-fcolor-diagnostics']
   return cmd
 
 def build_libs(args):


### PR DESCRIPTION
When the input C program is not syntactically correct, SMACK redirects
Clang's output to stdout. However, the message is not colorized, which
can make debugging cumbersome as it's hard to quickly identify the errors.

This commit solves this problem by adding a special flag to Clang such that
the output is colorized if SMACK's output is a tty device, otherwise it is
disabled to avoid annoying color information printed in a file.