### PR TITLE
Fixes to math.h functions/macros

### DIFF
--- a/share/smack/include/math/math.h
+++ b/share/smack/include/math/math.h
@@ -4,6 +4,27 @@
 #ifndef MATH_H
 #define MATH_H
 
+enum
+  {
+    FP_NAN,
+# define FP_NAN FP_NAN
+    FP_INFINITE,
+# define FP_INFINITE FP_INFINITE
+    FP_ZERO,
+# define FP_ZERO FP_ZERO
+    FP_SUBNORMAL,
+# define FP_SUBNORMAL FP_SUBNORMAL
+    FP_NORMAL
+# define FP_NORMAL FP_NORMAL
+  };
+
+#define fpclassify(x) (sizeof(x) == sizeof(float) ? __fpclassifyf(x) : __fpclassify(x))
+#define signbit(x) (sizeof(x) == sizeof(float) ? __signbitf(x) : __signbit(x))
+#define isfinite(x) (sizeof(x) == sizeof(float) ? __finitef(x) : __finite(x))
+#define isnormal(x) (sizeof(x) == sizeof(float) ? __isnormalf(x) : __isnormal(x))
+#define isnan(x) (sizeof(x) == sizeof(float) ? __isnanf(x) : __isnan(x))
+#define isinf(x) (sizeof(x) == sizeof(float) ? __isinff(x) : __isinf(x))
+
 float fabsf(float x);
 float fdimf(float x, float y);
 float roundf(float x);
@@ -30,7 +51,7 @@ int __isnanf(float x);
 int __isnegativef(float x);
 int __signbitf(float x);
 int __fpclassifyf(float x);
-int __isfinitef(float x);
+int __finitef(float x);
 
 double fabs(double x);
 double fdim(double x, double y);
@@ -58,6 +79,6 @@ int __isnan(double x);
 int __isnegative(double x);
 int __signbit(double x);
 int __fpclassify(double x);
-int __isfinite(double x);
+int __finite(double x);
 
 #endif

--- a/share/smack/lib/math.c
+++ b/share/smack/lib/math.c
@@ -165,17 +165,17 @@ int __signbitf(float x) {
 
 int __fpclassifyf(float x) {
   if (__isnanf(x))
-    return 0;
+    return FP_NAN;
   if (__isinff(x))
-    return 1;
+    return FP_INFINITE;
   if (__iszerof(x))
-    return 2;
+    return FP_ZERO;
   if (__issubnormalf(x))
-    return 3;
-  return 4;
+    return FP_SUBNORMAL;
+  return FP_NORMAL;
 }
 
-int __isfinitef(float x) {
+int __finitef(float x) {
   return !__isinff(x) && !__isnanf(x);
 }
 
@@ -341,16 +341,16 @@ int __signbit(double x) {
 
 int __fpclassify(double x) {
   if (__isnan(x))
-    return 0;
+    return FP_NAN;
   if (__isinf(x))
-    return 1;
+    return FP_INFINITE;
   if (__iszero(x))
-    return 2;
+    return FP_ZERO;
   if (__issubnormal(x))
-    return 3;
-  return 4;
+    return FP_SUBNORMAL;
+  return FP_NORMAL;
 }
 
-int __isfinite(double x) {
+int __finite(double x) {
   return !__isinf(x) && !__isnan(x);
 }


### PR DESCRIPTION
This pull request:
-Changes the names of the __isfinite and __isfinitef functions to
__finite and __finitef, respectively, in order to be consistent with the
C standard
-Adds several macros specified in the C standard