### PR TITLE
Fixes to modff and modf functions in math.h

### DIFF
--- a/share/smack/lib/math.c
+++ b/share/smack/lib/math.c
@@ -107,8 +107,7 @@ float modff(float x, float *iPart) {
     fPart = 0.0f;
   } else {
     *iPart = truncf(x);
-    fPart = __VERIFIER_nondet_double();
-    __SMACK_code("@ := ftd($rmode, $fsub.bvdouble($rmode, dtf($rmode, @), dtf($rmode, @)));", fPart, x, *iPart);
+    __SMACK_code("@ := ftd($rmode, $fsub.bvfloat($rmode, dtf($rmode, @), dtf($rmode, @)));", fPart, x, *iPart);
   }
   if (__iszerof(fPart)) {
     fPart = __signbitf(x) ? -0.0f : 0.0f;
@@ -285,7 +284,6 @@ double modf(double x, double *iPart) {
     fPart = 0.0;
   } else {
     *iPart = trunc(x);
-    fPart = __VERIFIER_nondet_double();
     __SMACK_code("@ := $fsub.bvdouble($rmode, @, @);", fPart, x, *iPart);
   }
   if (__iszero(fPart)) {


### PR DESCRIPTION
This pull request:
-Fixes error in modff function where $fsub.bvdouble was being called
instead of $fsub.bvfloat
-Removes unnecessary call to __VERIFIER_nondet_double() in modff and
modf