### PR TITLE
Added string.h include for memset declaration.

### DIFF
--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -5,6 +5,7 @@
 #include <limits.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <string.h>
 
 /**
  * The SMACK "prelude" definitions


### PR DESCRIPTION
When compiling C++ code, e.g., with the following:
```
smack a.cpp --clang-options="-x c++ -std=c++14"
```
Clang emits a warning due to a missing declaration:
```
/usr/local/share/smack/lib/smack.c:255:5: error: use of undeclared identifier 'memset'
    memset(ret, 0, num * size);
    ^
```

This PR adds the declaration by including the `string.h` header.