### PR TITLE
Compatibility with Python-3-default systems.

### DIFF
--- a/bin/smack
+++ b/bin/smack
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # This file is distributed under the MIT License. See LICENSE for details.
 #

--- a/bin/smack-doctor
+++ b/bin/smack-doctor
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # This file is distributed under the MIT License. See LICENSE for details.
 #

--- a/bin/vsmack
+++ b/bin/vsmack
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import os.path

--- a/share/smack/doctor.py
+++ b/share/smack/doctor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # This file is distributed under the MIT License. See LICENSE for details.
 #

--- a/share/smack/reach.py
+++ b/share/smack/reach.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # This file is distributed under the MIT License. See LICENSE for details.
 #

--- a/share/smack/svcomp/toSVCOMPformat.py
+++ b/share/smack/svcomp/toSVCOMPformat.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import xml.etree as etree
 import xml.etree.ElementTree as ET

--- a/svcomp/bench/src/SMACKBench.py
+++ b/svcomp/bench/src/SMACKBench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 sys.dont_write_bytecode = True # prevent creation of .pyc files
 

--- a/svcomp/bench/src/checkWitnesses.py
+++ b/svcomp/bench/src/checkWitnesses.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import xml.etree.ElementTree as ET
 import os

--- a/svcomp/bench/src/data/index.py
+++ b/svcomp/bench/src/data/index.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from lib import *
 import sys
 import cgitb

--- a/svcomp/bench/src/data/results.py
+++ b/svcomp/bench/src/data/results.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from lib import *
 import datetime
 import subprocess

--- a/test/reach/regtest.py
+++ b/test/reach/regtest.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import subprocess
 import re
@@ -75,4 +75,3 @@ if __name__ == '__main__':
   
   print '\nPASSED count: ', passed
   print 'FAILED count: ', failed
-

--- a/test/regtest.py
+++ b/test/regtest.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 from os import path
 from multiprocessing.pool import ThreadPool


### PR DESCRIPTION
Smack only works with Python version 2. On systems where version 3 is the default, Smack can still work simply by specifying `python2` as the interpreter.