### PR TITLE
Added test for uninterpreted functions.

### DIFF
--- a/test/basic/uninterpreted.c
+++ b/test/basic/uninterpreted.c
@@ -1,0 +1,19 @@
+#include <smack.h>
+
+// @expect verified
+
+int foo(int x) {
+  int y = __VERIFIER_nondet_int();
+  __SMACK_top_decl("function FOO(x: int): int;");
+  __SMACK_code("@ := FOO(@);", y, x);
+  return y;
+}
+
+
+int main(void) {
+  int x = foo(42);
+  int y = foo(42);
+  assert(x == y);
+
+  return 0;
+}

--- a/test/basic/uninterpreted_fail.c
+++ b/test/basic/uninterpreted_fail.c
@@ -1,0 +1,19 @@
+#include <smack.h>
+
+// @expect error
+
+int foo(int x) {
+  int y = __VERIFIER_nondet_int();
+  __SMACK_top_decl("function FOO(x: int): int;");
+  __SMACK_code("@ := FOO(@);", y, x);
+  return y;
+}
+
+
+int main(void) {
+  int x = foo(42);
+  int y = foo(43);
+  assert(x == y);
+
+  return 0;
+}


### PR DESCRIPTION
Inspired by a question asked by Nathan Chong, I thought it would be nice to share and preserve this recipe for functions which are _uninterpreted_ in the logical sense, in that a given call `f(x)` may return any value, but for `x == y` we are guaranteed that `f(x) == f(y)`.