### PR TITLE
Quick fixes for svcomp frontend

### DIFF
--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from utils import temporary_file, try_command
-from svcomp.utils import svcomp_frontend
 
 def languages():
   """A dictionary of languages per file extension."""
@@ -26,6 +25,10 @@ def languages():
 
 def frontends():
   """A dictionary of front-ends per language."""
+
+  # Avoid circular import
+  from svcomp.utils import svcomp_frontend
+
   return {
     'c'        : clang_frontend,
     'cxx'      : clang_plusplus_frontend,

--- a/share/smack/svcomp/utils.py
+++ b/share/smack/svcomp/utils.py
@@ -5,6 +5,7 @@ import subprocess
 import time
 from shutil import copyfile
 import smack.top
+import smack.frontend
 import filters
 from toSVCOMPformat import smackJsonToXmlGraph
 from random_testing import random_test
@@ -60,7 +61,12 @@ def svcomp_frontend(input_file, args):
     # Ensure clang runs the preprocessor, even with .i extension.
     args.clang_options += " -x c"
 
-  smack.top.clang_frontend(args)
+  bc = smack.frontend.clang_frontend(input_file, args)
+
+  # run with no extra smack libraries
+  libs = set()
+
+  smack.top.link_bc_files([bc],libs,args)
 
 def svcomp_check_property(args):
   # Check if property is vanilla reachability, and return unknown otherwise


### PR DESCRIPTION
Update the svcomp frontend to work
with the new cross-language structure

This includes

-- importing fronend.py as well as top.py
-- getting rid of a circular import in frontend.py
-- changing the svcomp frontend to use new functions