### PR TITLE
Fix SV-COMP witness generation

### DIFF
--- a/share/smack/svcomp/utils.py
+++ b/share/smack/svcomp/utils.py
@@ -438,7 +438,7 @@ def verify_bpl_svcomp(args):
     sys.exit(smack.top.results(args)[result])
 
 def write_error_file(args, status, verifier_output):
-  return
+  #return
   if args.memory_safety or status == 'timeout' or status == 'unknown':
     return
   hasBug = (status != 'verified')


### PR DESCRIPTION
This commit does the following,
1. Updated SMACK's JSON output generation according to Corral's C
trace format changes.
2. Updated JSON-to-witness-trace translation.
3. Simplified some logic in related scripts.