### PR TITLE
Add checking for left-shift overflows in C programs

### DIFF
--- a/include/smack/IntegerOverflowChecker.h
+++ b/include/smack/IntegerOverflowChecker.h
@@ -24,8 +24,8 @@ private:
   llvm::Value* extendBitWidth(llvm::Value* v, int bits, bool isSigned, llvm::Instruction* i);
   llvm::BinaryOperator* createFlag(llvm::Value* v, int bits, bool isSigned, llvm::Instruction* i);
   llvm::Value* createResult(llvm::Value* v, int bits, llvm::Instruction* i);
-  void addCheck(llvm::Function* co, llvm::BinaryOperator* flag, llvm::Instruction* i);
-  void addBlockingAssume(llvm::Function* va, llvm::BinaryOperator* flag, llvm::Instruction* i);
+  void addCheck(llvm::Function* co, llvm::Value* flag, llvm::Instruction* i);
+  void addBlockingAssume(llvm::Function* va, llvm::Value* flag, llvm::Instruction* i);
 };
 }
 

--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -72,7 +72,7 @@ def default_clang_compile_command(args, lib = False):
   cmd += args.clang_options.split()
   cmd += ['-DMEMORY_MODEL_' + args.mem_mod.upper().replace('-','_')]
   if args.memory_safety: cmd += ['-DMEMORY_SAFETY']
-  if args.integer_overflow: cmd += (['-ftrapv'] if not lib else ['-DSIGNED_INTEGER_OVERFLOW_CHECK'])
+  if args.integer_overflow: cmd += (['-ftrapv', '-fsanitize=shift'] if not lib else ['-DSIGNED_INTEGER_OVERFLOW_CHECK'])
   if args.float: cmd += ['-DFLOAT_ENABLED']
   if sys.stdout.isatty(): cmd += ['-fcolor-diagnostics']
   return cmd

--- a/test/bits/left_shift_negative_fail.c
+++ b/test/bits/left_shift_negative_fail.c
@@ -1,0 +1,11 @@
+#include "smack.h"
+
+// @expect error
+// @flag --integer-overflow
+
+int main(void) {
+  int x = __VERIFIER_nondet_int();
+  int z = 0;
+  assume(x < 0);
+  return x << z;
+}

--- a/test/bits/left_shift_overflow.c
+++ b/test/bits/left_shift_overflow.c
@@ -1,0 +1,12 @@
+#include "smack.h"
+
+// @expect verified
+// @flag --integer-overflow
+
+int main(void) {
+  int x = __VERIFIER_nondet_int();
+  int z = __VERIFIER_nondet_int();
+  assume(x < 1024 && x >= 0);
+  assume(0 <= z && z <= 21);
+  return x << z;
+}

--- a/test/bits/left_shift_overflow_fail.c
+++ b/test/bits/left_shift_overflow_fail.c
@@ -1,0 +1,12 @@
+#include "smack.h"
+
+// @expect error
+// @flag --integer-overflow
+
+int main(void) {
+  int x = __VERIFIER_nondet_int();
+  int z = __VERIFIER_nondet_int();
+  assume(x >= 1024);
+  assume(0 <= z && z <= 21);
+  return x << z;
+}

--- a/test/bits/left_shift_unsigned.c
+++ b/test/bits/left_shift_unsigned.c
@@ -1,0 +1,12 @@
+#include "smack.h"
+
+// @expect verified
+// @flag --integer-overflow
+
+int main(void) {
+  unsigned int x = __VERIFIER_nondet_unsigned_int();
+  unsigned int z = __VERIFIER_nondet_unsigned_int();
+
+  assume(z < sizeof(x)*8);
+  return x << z;
+}

--- a/test/bits/left_shift_unsigned_fail.c
+++ b/test/bits/left_shift_unsigned_fail.c
@@ -1,0 +1,12 @@
+#include "smack.h"
+
+// @expect error
+// @flag --integer-overflow
+
+int main(void) {
+  unsigned int x = __VERIFIER_nondet_unsigned_int();
+  unsigned int z = __VERIFIER_nondet_unsigned_int();
+
+  assume(z >= sizeof(x)*8);
+  return x << z;
+}


### PR DESCRIPTION
Changes:
* `--integer-overflow` enables the clang option `-fsanitize=shift`.
* `__ubsan_handle_shift_out_of_bounds` is transformed to assert false with the `overflow` annotation.
* Tests for shifting with a negative negative LHS, left shifting non-negative signed-values, and unsigned values are included.

UBSan does all the work for us to detect undefined left bit shifts. It will check that the shift amount is appropriate for the bit width. For signed left shifts, it performs a right shift of `(bit-width - 1 - left_shift_amt)` bits and checks if this is zero. If it's not zero, then the left shift would shift a `1` past the MSB, which is undefined.

This is meant to fix issue #382.