### PR TITLE
Fixed isfinite() macro

### DIFF
--- a/share/smack/include/math.h
+++ b/share/smack/include/math.h
@@ -15,7 +15,7 @@
 #define isnan(x) (sizeof(x) == sizeof(long double) ? __isnanl(x) : sizeof(x) == sizeof(double) ? __isnan(x) : __isnanf(x))
 #define signbit(x) (sizeof(x) == sizeof(long double) ? __signbitl(x) : sizeof(x) == sizeof(double) ? __signbit(x) : __signbitf(x))
 #define fpclassify(x) (sizeof(x) == sizeof(long double) ? __fpclassifyl(x) : sizeof(x) == sizeof(double) ? __fpclassify(x) : __fpclassifyf(x))
-#define isfinite(x) (sizeof(x) == sizeof(long double) ? __isfinitel(x) : sizeof(x) == sizeof(double) ? __finite(x) : __finitef(x))
+#define isfinite(x) (sizeof(x) == sizeof(long double) ? __finitel(x) : sizeof(x) == sizeof(double) ? __finite(x) : __finitef(x))
 
 typedef union {
   float f;


### PR DESCRIPTION
The macro currently calls __isfinitel, but the function is called __finitel.