### PR TITLE
Got rid of quantified axioms related to floating-points

### DIFF
--- a/include/smack/SmackRep.h
+++ b/include/smack/SmackRep.h
@@ -156,6 +156,8 @@ public:
   std::string getString(const llvm::Value* v);
   bool isExternal(const llvm::Value* v);
   void addBplGlobal(std::string name);
+  const Stmt* inverseFPCastAssume(const llvm::Value* src, const llvm::Type* destType);
+  const Stmt* inverseFPCastAssume(const llvm::StoreInst* si);
 
   // used in SmackModuleGenerator
   std::list<Decl*> globalDecl(const llvm::GlobalValue* g);

--- a/lib/smack/SmackRep.cpp
+++ b/lib/smack/SmackRep.cpp
@@ -18,14 +18,13 @@
 
 namespace {
   using namespace llvm;
-  using namespace std;
 
-  list<CallInst*> findCallers(Function* F) {
-    list<CallInst*> callers;
+  std::list<CallInst*> findCallers(Function* F) {
+    std::list<CallInst*> callers;
 
     if (F) {
-      queue<User*> users;
-      set<User*> covered;
+      std::queue<User*> users;
+      std::set<User*> covered;
 
       users.push(F);
       covered.insert(F);
@@ -1179,7 +1178,7 @@ const Stmt* SmackRep::inverseFPCastAssume(const Value* src, const Type* destType
   if (!(srcType->isFloatingPointTy() && destType->isIntegerTy())) {
     return nullptr;
   }
-  string fn = Naming::INSTRUCTION_TABLE.at(Instruction::BitCast);
+  std::string fn = Naming::INSTRUCTION_TABLE.at(Instruction::BitCast);
   const Expr *srcExpr = expr(src);
   const Expr *castFPToInt = Expr::fn(opName(fn, {src->getType(), destType}), srcExpr);
   const Expr *castIntToFP = Expr::fn(opName(fn, {destType, src->getType()}), castFPToInt);

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -1147,23 +1147,6 @@ void __SMACK_decls(void) {
   DECLARE(UNINTERPRETED_CONVERSION,i32,bvfloat,$bitcast);
   DECLARE(UNINTERPRETED_CONVERSION,i64,bvdouble,$bitcast);
   DECLARE(UNINTERPRETED_CONVERSION,i80,bvlongdouble,$bitcast);
-  D("axiom (forall f: bvhalf :: $bitcast.bv16.bvhalf($bitcast.bvhalf.bv16(f)) == f);");
-  D("axiom (forall f: bvfloat :: $bitcast.bv32.bvfloat($bitcast.bvfloat.bv32(f)) == f);");
-  D("axiom (forall f: bvdouble :: $bitcast.bv64.bvdouble($bitcast.bvdouble.bv64(f)) == f);");
-  D("axiom (forall f: bvlongdouble :: $bitcast.bv80.bvlongdouble($bitcast.bvlongdouble.bv80(f)) == f);");
-  //D("axiom (forall b: bv16 :: b[15:10] == 31bv5 && b[10:0] != 0bv10 ==> $bitcast.bvhalf.bv16($bitcast.bv16.bvhalf(b)) == b);");
-  //D("axiom (forall b: bv32 :: b[31:23] == 255bv8 && b[23:0] != 0bv23 ==> $bitcast.bvfloat.bv32($bitcast.bv32.bvfloat(b)) == b);");
-  //D("axiom (forall b: bv64 :: b[63:52] == 2047bv11 && b[52:0] != 0bv52 ==> $bitcast.bvdouble.bv64($bitcast.bv64.bvdouble(b)) == b);");
-  //D("axiom (forall b: bv80 :: b[79:64] == 32768bv15 && b[64:0] != 0bv64 ==> $bitcast.bvlongdouble.bv80($bitcast.bv80.bvlongdouble(b)) == b);");
-  // TODO: add more constraints
-
-  D("axiom (forall f: bvfloat, rm1: rmode, rm2: rmode :: dtf(rm1, ftd(rm2, f)) == f);");
-  D("axiom (forall f: bvlongdouble, rm1: rmode, rm2: rmode :: dtl(rm1, ltd(rm2, f)) == f);");
-
-  D("axiom (forall f: bvhalf, i: i16 :: $bitcast.bvhalf.i16(f) == i <==> $bitcast.i16.bvhalf(i) == f);");
-  D("axiom (forall f: bvfloat, i: i32 :: $bitcast.bvfloat.i32(f) == i <==> $bitcast.i32.bvfloat(i) == f);");
-  D("axiom (forall f: bvdouble, i: i64 :: $bitcast.bvdouble.i64(f) == i <==> $bitcast.i64.bvdouble(i) == f);");
-  D("axiom (forall f: bvlongdouble, i: i80 :: $bitcast.bvlongdouble.i80(f) == i <==> $bitcast.i80.bvlongdouble(i) == f);");
 
   D("function {:inline} $load.bvhalf(M: [ref] bvhalf, p: ref) returns (bvhalf) { M[p] }");
   D("function {:inline} $store.bvhalf(M: [ref] bvhalf, p: ref, v: bvhalf) returns ([ref] bvhalf) { M[p := v] }");

--- a/test/float/bitcast.c
+++ b/test/float/bitcast.c
@@ -10,3 +10,4 @@ int main(void) {
   assert (i == i1);
   return 0;
 }
+

--- a/test/float/bitcast_fail.c
+++ b/test/float/bitcast_fail.c
@@ -10,3 +10,4 @@ int main(void) {
   assert (i != i1);
   return 0;
 }
+

--- a/test/float/float_int_union.c
+++ b/test/float/float_int_union.c
@@ -1,0 +1,24 @@
+#include "smack.h"
+
+// @flag --bit-precise
+// @expect verified
+
+union mix {
+  float f;
+  int i;
+};
+
+int sum_to_int(float a, float b) {
+  float sum = a + b;
+  union mix m;
+  m.f = sum;
+  return m.i;
+}
+
+int main(void) {
+  int i;
+  i = sum_to_int(-0x1.6b890ep+29, 0x1.6b890ep+29);
+  assert(i == 0);
+  return 0;
+}
+

--- a/test/float/float_int_union_fail.c
+++ b/test/float/float_int_union_fail.c
@@ -1,0 +1,24 @@
+#include "smack.h"
+
+// @flag --bit-precise
+// @expect error
+
+union mix {
+  float f;
+  int i;
+};
+
+int sum_to_int(float a, float b) {
+  float sum = a + b;
+  union mix m;
+  m.f = sum;
+  return m.i;
+}
+
+int main(void) {
+  int i;
+  i = sum_to_int(0x1.6b890ep+29, 0x1.6b890ep+29);
+  assert(i == 0);
+  return 0;
+}
+


### PR DESCRIPTION
Now turning on precise reasoning about floats does not generate
Boogie files with quantifiers.
First, we realized that a bunch of axioms was not needed in the
first place, and so I just removed those.
Second, whenever a cast such as $bitcast.bvfloat.bv32(x) gets
introduced, which happens due to bitcast instructions or stores
into byte maps, I introduce an assume statement such as:
assume ($bitcast.bv32.bvfloat($bitcast.bvfloat.bv32(x)) == x);
This appropriately constrains the uninterpreted
$bitcast.bvfloat.bv32 function.

Closes #412