### PR TITLE
Enable SMACK to build a no-std Rust crate

### DIFF
--- a/share/smack/lib/smack.rs
+++ b/share/smack/lib/smack.rs
@@ -97,6 +97,7 @@ make_nondet!(usize, __VERIFIER_nondet_unsigned_long_long);
 
 
 #[cfg(not(verifier = "smack"))]
+#[cfg(feature = "std")]
 #[allow(dead_code)]
 use std::Vec;
 /* Vector class.


### PR DESCRIPTION
As the name suggests, this feature gates the standard Vec class to enable building in no standard Rust programs.