### PR TITLE
enable extractvalue functions when the `--bit-precise` flag is used

### DIFF
--- a/include/smack/SmackRep.h
+++ b/include/smack/SmackRep.h
@@ -70,7 +70,6 @@ private:
   const Expr* pointerToInteger(const Expr* e, unsigned width);
   const Expr* integerToPointer(const Expr* e, unsigned width);
 
-  std::string opName(const std::string& operation, std::list<const llvm::Type*> types);
   std::string opName(const std::string& operation, std::initializer_list<unsigned> types);
 
   const Stmt* store(unsigned R, const llvm::Type* T, const Expr* P, const Expr* V);
@@ -174,6 +173,7 @@ public:
 
   void addAuxiliaryDeclaration(Decl* D);
   std::list<Decl*> auxiliaryDeclarations();
+  std::string opName(const std::string& operation, std::list<const llvm::Type*> types);
 };
 
 }

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -1207,7 +1207,6 @@ void __SMACK_decls(void) {
 
   D("var $exn: bool;");
   D("var $exnv: int;");
-  D("function $extractvalue(p: int, i: int) returns (int);\n");
 
   D("procedure $alloc(n: ref) returns (p: ref)\n"
     "{\n"


### PR DESCRIPTION
This PR addresses issue #441.