### PR TITLE
Add support for the LLVM half-conversion intrinsics

### DIFF
--- a/include/smack/SmackInstGenerator.h
+++ b/include/smack/SmackInstGenerator.h
@@ -40,6 +40,7 @@ private:
   void generateGotoStmts(llvm::Instruction& i,
                          std::vector<std::pair<const Expr*, llvm::BasicBlock*> > target);
   void processInstruction(llvm::Instruction& i);
+  void processIntrinsicCall(llvm::IntrinsicInst* ii);
   void nameInstruction(llvm::Instruction& i);
   void annotate(llvm::Instruction& i, Block* b);
 

--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -74,6 +74,7 @@ def default_clang_compile_command(args, lib = False):
   if args.memory_safety: cmd += ['-DMEMORY_SAFETY']
   if args.integer_overflow: cmd += (['-ftrapv', '-fsanitize=shift'] if not lib else ['-DSIGNED_INTEGER_OVERFLOW_CHECK'])
   if args.float: cmd += ['-DFLOAT_ENABLED']
+  if args.bit_precise: cmd += ['-DBIT_PRECISE']
   if sys.stdout.isatty(): cmd += ['-fcolor-diagnostics']
   return cmd
 
@@ -239,7 +240,7 @@ def rust_frontend(input_file, args):
 def default_build_libs(args):
   """Generate LLVM bitcodes for SMACK libraries."""
   bitcodes = []
-  libs = ['smack.c', 'stdlib.c', 'errno.c']
+  libs = ['smack.c', 'stdlib.c', 'errno.c', 'intrinsics.c']
 
   if args.pthread:
     libs += ['pthread.c']

--- a/share/smack/lib/intrinsics.c
+++ b/share/smack/lib/intrinsics.c
@@ -1,0 +1,43 @@
+#include "smack.h"
+
+#if FLOAT_ENABLED && BIT_PRECISE
+float __SMACK_convert_from_fp16_f32(unsigned short x) {
+  float ret = __VERIFIER_nondet_float();
+  __SMACK_code("@f := $fpext.bvhalf.bvfloat($rmode, $bitcast.bv16.bvhalf(@H));", ret, x);
+  return ret;
+}
+
+double __SMACK_convert_from_fp16_f64(unsigned short x) {
+  double ret = __VERIFIER_nondet_double();
+  __SMACK_code("@ := $fpext.bvhalf.bvdouble($rmode, $bitcast.bv16.bvhalf(@H));", ret, x);
+  return ret;
+}
+
+unsigned short __SMACK_convert_to_fp16_f32(float x) {
+  unsigned short ret = __VERIFIER_nondet_unsigned_short();
+  __SMACK_code("assume($bitcast.bv16.bvhalf(@H) == $fptrunc.bvfloat.bvhalf($rmode, @f));", ret, x);
+  return ret;
+}
+
+unsigned short __SMACK_convert_to_fp16_f64(double x) {
+  unsigned short ret = __VERIFIER_nondet_unsigned_short();
+  __SMACK_code("assume $bitcast.bv16.bvhalf(@H) == $fptrunc.bvdouble.bvhalf($rmode, @);", ret, x);
+  return ret;
+}
+#else
+float __SMACK_convert_from_fp16_f32(unsigned short x) {
+  return __VERIFIER_nondet_float();
+}
+
+double __SMACK_convert_from_fp16_f64(unsigned short x) {
+  return __VERIFIER_nondet_double();
+}
+
+unsigned short __SMACK_convert_to_fp16_f32(float x) {
+  return __VERIFIER_nondet_unsigned_short();
+}
+
+unsigned short __SMACK_convert_to_fp16_f64(double x) {
+  return __VERIFIER_nondet_unsigned_short();
+}
+#endif

--- a/test/float/half_intrinsics.c
+++ b/test/float/half_intrinsics.c
@@ -1,0 +1,16 @@
+#include "smack.h"
+#include "math.h"
+
+// @flag --bit-precise
+// @expect verified
+
+int main(void) {
+  union {unsigned short u; __fp16 h;} uh;
+  uh.u = 1U;
+  assert(isnormal((float)uh.h));
+  assert(isnormal((double)uh.h));
+  uh.h = 66504.0f;
+  assert(uh.u == 31744U);
+  uh.h = 66504.0;
+  assert(uh.u == 31744U);
+}

--- a/test/float/half_intrinsics_fail.c
+++ b/test/float/half_intrinsics_fail.c
@@ -1,0 +1,16 @@
+#include "smack.h"
+#include "math.h"
+
+// @flag --bit-precise
+// @expect error
+
+int main(void) {
+  union {unsigned short u; __fp16 h;} uh;
+  uh.u = 1U;
+  assert(isnormal((float)uh.h));
+  assert(isnormal((double)uh.h));
+  uh.h = 66504.0f;
+  assert(uh.u != 31744U);
+  uh.h = 66504.0;
+  assert(uh.u == 31744U);
+}


### PR DESCRIPTION
This adds support for the LLVM conversion intrinsics for converting: `f64`->`f16`,  `f32`->`f16`,  `f16`->`f64` and `f16`->`f32`.
Since the normal mode of LLVM is to use half precision as an IEEE binary16 storage format, this should be all we need for now. (BFloat16 hardware is a ways off apparently.)
Addresses #436.