### PR TITLE
 Added regression that tests issue with __finite function in LLVM 4.0.1

### DIFF
--- a/test/float/llvm_intrinsic.c
+++ b/test/float/llvm_intrinsic.c
@@ -1,0 +1,11 @@
+#include "smack.h"
+#include <math.h>
+
+//@expect verified
+
+int main(void) {
+  double f = __VERIFIER_nondet_double();
+  assume(isfinite(f));
+  assert(f + 0.0 == f);
+  return 0;
+}

--- a/test/float/llvm_intrinsic_fail.c
+++ b/test/float/llvm_intrinsic_fail.c
@@ -1,0 +1,11 @@
+#include "smack.h"
+#include <math.h>
+
+//@expect error
+
+int main(void) {
+  double f = __VERIFIER_nondet_double();
+  assume(isfinite(f));
+  assert(f + 0.0 != f);
+  return 0;
+}


### PR DESCRIPTION
This adds a regression for testing an issue with the __finite function that is present with LLVM version 4.0.1. This problem is described further in Issue [#449](https://github.com/smackers/smack/issues/449).