### PR TITLE
[WIP] Add LLVM bit intrinsics

### DIFF
--- a/include/smack/BoogieAst.h
+++ b/include/smack/BoogieAst.h
@@ -282,6 +282,7 @@ public:
   static const Stmt* comment(std::string c);
   static const Stmt* goto_(std::list<std::string> ts);
   static const Stmt* havoc(std::string x);
+  static const Stmt* havoc(const Expr* x);
   static const Stmt* return_();
   static const Stmt* return_(const Expr* e);
   static const Stmt* skip();

--- a/lib/smack/BoogieAst.cpp
+++ b/lib/smack/BoogieAst.cpp
@@ -225,6 +225,12 @@ const Stmt* Stmt::havoc(std::string x) {
   return new HavocStmt(std::list<std::string>(1, x));
 }
 
+const Stmt* Stmt::havoc(const Expr* x) {
+  std::stringstream s;
+  s << x;
+  return new HavocStmt(std::list<std::string>(1, s.str()));
+}
+
 const Stmt* Stmt::return_(const Expr* e) {
   return new ReturnStmt(e);
 }

--- a/test/bits/bitreverse.c
+++ b/test/bits/bitreverse.c
@@ -1,0 +1,55 @@
+#include "smack.h"
+#include <stdint.h>
+
+// @expect verified
+
+uint16_t bitreverse16(uint16_t x) {
+  uint16_t result = 0;
+  result |= (x&0x0001) << 15; // 0->15
+  result |= (x&0x0002) << 13; // 1->14
+  result |= (x&0x0004) << 11; // 2->13
+  result |= (x&0x0008) << 9;  // 3->12
+  result |= (x&0x0010) << 7;  // 4->11
+  result |= (x&0x0020) << 5;  // 5->10
+  result |= (x&0x0040) << 3;  // 6->9
+  result |= (x&0x0080) << 1;  // 7->8
+  result |= (x&0x0100) >> 1;  // 8->7
+  result |= (x&0x0200) >> 3;  // 9->6
+  result |= (x&0x0400) >> 5;  // 10->5
+  result |= (x&0x0800) >> 7;  // 11->4
+  result |= (x&0x1000) >> 9;  // 12->3
+  result |= (x&0x2000) >> 11; // 13->2
+  result |= (x&0x4000) >> 13; // 14->1
+  result |= (x&0x8000) >> 15; // 15->0
+  return result;
+}
+
+uint32_t bitreverse32(uint32_t x) {
+  uint32_t result = 0;
+  result |= (x&0x01) << 31;  // 0->31
+  result |= (x&0x02) << 29;  // 1->30
+  result |= (x&0x04) << 27;  // 2->29
+  result |= (x&0x08) << 25;  // 3->28
+  result |= (x&0x10) << 23;  // 4->27
+  result |= (x&0x20) << 21;  // 5->26
+  result |= (x&0x40) << 19;  // 6->25
+  result |= (x&0x80) << 17;  // 7->24
+  result |= bitreverse16((x>>8)&0xFFFF) << 8;
+  result |= (x&0x01000000) >> 17; // 24->7
+  result |= (x&0x02000000) >> 19; // 25->6
+  result |= (x&0x04000000) >> 21; // 26->5
+  result |= (x&0x08000000) >> 23; // 27->4
+  result |= (x&0x10000000) >> 25; // 28->3
+  result |= (x&0x20000000) >> 27; // 29->2
+  result |= (x&0x40000000) >> 29; // 30->1
+  result |= (x&0x80000000) >> 31; // 31->0
+  return result;
+}
+
+int main(void) {
+  uint16_t x = __VERIFIER_nondet_unsigned_short();
+  uint32_t y = __VERIFIER_nondet_unsigned_int();
+  assert(__builtin_bitreverse16(x) == bitreverse16(x));
+  assert(__builtin_bitreverse32(y) == bitreverse32(y));
+  return 0;
+}

--- a/test/bits/bitreverse_fail.c
+++ b/test/bits/bitreverse_fail.c
@@ -1,0 +1,55 @@
+#include "smack.h"
+#include <stdint.h>
+
+// @expect error
+
+uint16_t bitreverse16(uint16_t x) {
+  uint16_t result = 0;
+  result |= (x&0x0001) << 15; // 0->15
+  result |= (x&0x0002) << 13; // 1->14
+  result |= (x&0x0004) << 11; // 2->13
+  result |= (x&0x0008) << 9;  // 3->12
+  result |= (x&0x0010) << 7;  // 4->11
+  result |= (x&0x0020) << 5;  // 5->10
+  result |= (x&0x0040) << 3;  // 6->9
+  result |= (x&0x0080) << 1;  // 7->8
+  result |= (x&0x0100) >> 1;  // 8->7
+  result |= (x&0x0200) >> 3;  // 9->6
+  result |= (x&0x0400) >> 5;  // 10->5
+  result |= (x&0x0800) >> 7;  // 11->4
+  result |= (x&0x1000) >> 9;  // 12->3
+  result |= (x&0x2000) >> 11; // 13->2
+  result |= (x&0x4000) >> 13; // 14->1
+  result |= (x&0x8000) >> 15; // 15->0
+  return result;
+}
+
+uint32_t bitreverse32(uint32_t x) {
+  uint32_t result = 0;
+  result |= (x&0x01) << 31;  // 0->31
+  result |= (x&0x02) << 29;  // 1->30
+  result |= (x&0x04) << 27;  // 2->29
+  result |= (x&0x08) << 25;  // 3->28
+  result |= (x&0x10) << 23;  // 4->27
+  result |= (x&0x20) << 21;  // 5->26
+  result |= (x&0x40) << 19;  // 6->25
+  result |= (x&0x80) << 17;  // 7->24
+  result |= bitreverse16((x>>8)&0xFFFF) << 8;
+  result |= (x&0x01000000) >> 17; // 24->7
+  result |= (x&0x02000000) >> 19; // 25->6
+  result |= (x&0x04000000) >> 21; // 26->5
+  result |= (x&0x08000000) >> 23; // 27->4
+  result |= (x&0x10000000) >> 25; // 28->3
+  result |= (x&0x20000000) >> 27; // 29->2
+  result |= (x&0x40000000) >> 29; // 30->1
+  result |= (x&0x80000000) >> 31; // 31->0
+  return result;
+}
+
+int main(void) {
+  uint16_t x = __VERIFIER_nondet_unsigned_short();
+  uint32_t y = __VERIFIER_nondet_unsigned_int();
+  assert(__builtin_bitreverse16(x) != bitreverse16(x) ||
+         __builtin_bitreverse32(y) != bitreverse32(y));
+  return 0;
+}

--- a/test/bits/byte_swap_fail.c
+++ b/test/bits/byte_swap_fail.c
@@ -37,7 +37,7 @@ int main(void) {
   uint32_t x32 = __VERIFIER_nondet_unsigned_int();
   uint64_t x64 = __VERIFIER_nondet_unsigned_long_long();
   assert(__builtin_bswap16(x16) != bswap16(x16) ||
-	 __builtin_bswap32(x32) != bswap32(x32) ||
-	 __builtin_bswap64(x64) != bswap64(x64));
+         __builtin_bswap32(x32) != bswap32(x32) ||
+         __builtin_bswap64(x64) != bswap64(x64));
   return 0;
 }

--- a/test/bits/countlz.c
+++ b/test/bits/countlz.c
@@ -1,0 +1,39 @@
+#include "smack.h"
+#include <stdint.h>
+
+// @expect verified
+
+uint32_t ctlz32(uint32_t x) {
+  uint32_t n = 32;
+  uint32_t y;
+
+  y = x >>16; if (y != 0) { n = n -16; x = y; }
+  y = x >> 8; if (y != 0) { n = n - 8; x = y; }
+  y = x >> 4; if (y != 0) { n = n - 4; x = y; }
+  y = x >> 2; if (y != 0) { n = n - 2; x = y; }
+  y = x >> 1; if (y != 0) return n - 2;
+  return n - x;
+}
+
+uint64_t ctlz64(uint64_t x) {
+  uint64_t n = 64;
+  uint64_t y;
+
+  y = x >>32; if (y != 0) { n = n -32; x = y; }
+  y = x >>16; if (y != 0) { n = n -16; x = y; }
+  y = x >> 8; if (y != 0) { n = n - 8; x = y; }
+  y = x >> 4; if (y != 0) { n = n - 4; x = y; }
+  y = x >> 2; if (y != 0) { n = n - 2; x = y; }
+  y = x >> 1; if (y != 0) return n - 2;
+  return n - x;
+}
+
+int main(void) {
+  uint32_t x32 = __VERIFIER_nondet_unsigned_int();
+  assume(x32 != 0);
+  uint64_t x64 = __VERIFIER_nondet_unsigned_long_long();
+  assume(x64 != 0);
+  assert(__builtin_clz(x32) == ctlz32(x32));
+  assert(__builtin_clzll(x64) == ctlz64(x64));
+  return 0;
+}

--- a/test/bits/countlz_fail.c
+++ b/test/bits/countlz_fail.c
@@ -1,0 +1,39 @@
+#include "smack.h"
+#include <stdint.h>
+
+// @expect error
+
+uint32_t ctlz32(uint32_t x) {
+  uint32_t n = 32;
+  uint32_t y;
+
+  y = x >>16; if (y != 0) { n = n -16; x = y; }
+  y = x >> 8; if (y != 0) { n = n - 8; x = y; }
+  y = x >> 4; if (y != 0) { n = n - 4; x = y; }
+  y = x >> 2; if (y != 0) { n = n - 2; x = y; }
+  y = x >> 1; if (y != 0) return n - 2;
+  return n - x;
+}
+
+uint64_t ctlz64(uint64_t x) {
+  uint64_t n = 64;
+  uint64_t y;
+
+  y = x >>32; if (y != 0) { n = n -32; x = y; }
+  y = x >>16; if (y != 0) { n = n -16; x = y; }
+  y = x >> 8; if (y != 0) { n = n - 8; x = y; }
+  y = x >> 4; if (y != 0) { n = n - 4; x = y; }
+  y = x >> 2; if (y != 0) { n = n - 2; x = y; }
+  y = x >> 1; if (y != 0) return n - 2;
+  return n - x;
+}
+
+int main(void) {
+  uint32_t x32 = __VERIFIER_nondet_unsigned_int();
+  assume(x32 != 0);
+  uint64_t x64 = __VERIFIER_nondet_unsigned_long_long();
+  assume(x64 != 0);
+  assert(__builtin_clz(x32) != ctlz32(x32) ||
+         __builtin_clzll(x64) != ctlz64(x64));
+  return 0;
+}

--- a/test/bits/countlz_fail2.c
+++ b/test/bits/countlz_fail2.c
@@ -1,0 +1,40 @@
+#include "smack.h"
+#include <stdint.h>
+
+// @expect error
+
+uint32_t ctlz32(uint32_t x) {
+  uint32_t n = 32;
+  uint32_t y;
+
+  y = x >>16; if (y != 0) { n = n -16; x = y; }
+  y = x >> 8; if (y != 0) { n = n - 8; x = y; }
+  y = x >> 4; if (y != 0) { n = n - 4; x = y; }
+  y = x >> 2; if (y != 0) { n = n - 2; x = y; }
+  y = x >> 1; if (y != 0) return n - 2;
+  return n - x;
+}
+
+uint64_t ctlz64(uint64_t x) {
+  uint64_t n = 64;
+  uint64_t y;
+
+  y = x >>32; if (y != 0) { n = n -32; x = y; }
+  y = x >>16; if (y != 0) { n = n -16; x = y; }
+  y = x >> 8; if (y != 0) { n = n - 8; x = y; }
+  y = x >> 4; if (y != 0) { n = n - 4; x = y; }
+  y = x >> 2; if (y != 0) { n = n - 2; x = y; }
+  y = x >> 1; if (y != 0) return n - 2;
+  return n - x;
+}
+
+int main(void) {
+  // It appears clang defaults to setting zero arguments
+  // to ctlz as having undefined results. This test
+  // should fail if this is true.
+  uint32_t x32 = __VERIFIER_nondet_unsigned_int();
+  uint64_t x64 = __VERIFIER_nondet_unsigned_long_long();
+  assert(__builtin_clz(x32) == ctlz32(x32) ||
+         __builtin_clzll(x64) == ctlz64(x64));
+  return 0;
+}

--- a/test/bits/countlz_zero_fail.c
+++ b/test/bits/countlz_zero_fail.c
@@ -1,0 +1,28 @@
+#include "smack.h"
+#include <stdint.h>
+
+// @expect error
+// @flag --unroll=3
+
+uint32_t ctlz32(uint32_t x) {
+  uint32_t n = 32;
+  uint32_t y;
+
+  y = x >>16; if (y != 0) { n = n -16; x = y; }
+  y = x >> 8; if (y != 0) { n = n - 8; x = y; }
+  y = x >> 4; if (y != 0) { n = n - 4; x = y; }
+  y = x >> 2; if (y != 0) { n = n - 2; x = y; }
+  y = x >> 1; if (y != 0) return n - 2;
+  return n - x;
+}
+
+int main(void) {
+  uint32_t x32 = 1;
+  uint32_t leadingZeros = 0;
+  for (int i = 0; i < 2; ++i) {
+    leadingZeros = __builtin_ctz(x32);
+    x32--;
+  }
+  assert(leadingZeros <= 32);
+  return 0;
+}

--- a/test/bits/countpop32.c
+++ b/test/bits/countpop32.c
@@ -1,0 +1,51 @@
+#include "smack.h"
+#include <stdint.h>
+
+// @expect verified
+
+uint32_t ctpop32(uint32_t x) {
+  uint32_t result = 0;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;
+  return result;
+}
+
+int main(void) {
+  uint32_t x = __VERIFIER_nondet_unsigned_int();
+  assume(x < 1<<16);
+  assert(__builtin_popcount(x) == ctpop32(x));
+  uint32_t y = __VERIFIER_nondet_unsigned_int();
+  assume(x >= 1<<16);
+  assert(__builtin_popcount(y) == ctpop32(y));
+  return 0;
+}

--- a/test/bits/countpop32_fail.c
+++ b/test/bits/countpop32_fail.c
@@ -1,0 +1,47 @@
+#include "smack.h"
+#include <stdint.h>
+
+// @expect error
+
+uint32_t ctpop32(uint32_t x) {
+  uint32_t result = 0;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;  x >>= 1;
+  result += x&1;
+  return result;
+}
+
+int main(void) {
+  uint32_t x = __VERIFIER_nondet_unsigned_int();
+  assert(__builtin_popcount(x) != ctpop32(x));
+  return 0;
+}

--- a/test/bits/counttz.c
+++ b/test/bits/counttz.c
@@ -1,0 +1,43 @@
+#include "smack.h"
+#include <stdint.h>
+
+// @expect verified
+
+uint32_t cttz32(uint32_t x)
+{
+  uint32_t n = 0; /* number of bits */
+
+  if (!(x & 0x0000FFFF)) { n += 16; x >>= 16; }
+  if (!(x & 0x000000FF)) { n +=  8; x >>=  8; }
+  if (!(x & 0x0000000F)) { n +=  4; x >>=  4; }
+  if (!(x & 0x00000003)) { n +=  2; x >>=  2; }
+
+  n += (x & 1) ^ 1;
+
+  return n;
+}
+
+uint64_t cttz64(uint64_t x)
+{
+  uint64_t n = 0; /* number of bits */
+
+  if (!(x & 0x00000000FFFFFFFF)) { n += 32; x >>= 32; }
+  if (!(x & 0x000000000000FFFF)) { n += 16; x >>= 16; }
+  if (!(x & 0x00000000000000FF)) { n +=  8; x >>=  8; }
+  if (!(x & 0x000000000000000F)) { n +=  4; x >>=  4; }
+  if (!(x & 0x0000000000000003)) { n +=  2; x >>=  2; }
+
+  n += (x & 1) ^ 1;
+
+  return n;
+}
+
+int main(void) {
+  uint32_t x32 = __VERIFIER_nondet_unsigned_int();
+  assume(x32 != 0);
+  uint64_t x64 = __VERIFIER_nondet_unsigned_long_long();
+  assume(x64 != 0);
+  assert(__builtin_ctz(x32) == cttz32(x32));
+  assert(__builtin_ctzll(x64) == cttz64(x64));
+  return 0;
+}

--- a/test/bits/counttz_fail.c
+++ b/test/bits/counttz_fail.c
@@ -1,0 +1,43 @@
+#include "smack.h"
+#include <stdint.h>
+
+// @expect error
+
+uint32_t cttz32(uint32_t x)
+{
+  uint32_t n = 0; /* number of bits */
+
+  if (!(x & 0x0000FFFF)) { n += 16; x >>= 16; }
+  if (!(x & 0x000000FF)) { n +=  8; x >>=  8; }
+  if (!(x & 0x0000000F)) { n +=  4; x >>=  4; }
+  if (!(x & 0x00000003)) { n +=  2; x >>=  2; }
+
+  n += (x & 1) ^ 1;
+
+  return n;
+}
+
+uint64_t cttz64(uint64_t x)
+{
+  uint64_t n = 0; /* number of bits */
+
+  if (!(x & 0x00000000FFFFFFFF)) { n += 32; x >>= 32; }
+  if (!(x & 0x000000000000FFFF)) { n += 16; x >>= 16; }
+  if (!(x & 0x00000000000000FF)) { n +=  8; x >>=  8; }
+  if (!(x & 0x000000000000000F)) { n +=  4; x >>=  4; }
+  if (!(x & 0x0000000000000003)) { n +=  2; x >>=  2; }
+
+  n += (x & 1) ^ 1;
+
+  return n;
+}
+
+int main(void) {
+  uint32_t x32 = __VERIFIER_nondet_unsigned_int();
+  assume(x32 != 0);
+  uint64_t x64 = __VERIFIER_nondet_unsigned_long_long();
+  assume(x64 != 0);
+  assert(__builtin_ctz(x32) != cttz32(x32) ||
+         __builtin_ctzll(x64) != cttz64(x64));
+  return 0;
+}

--- a/test/bits/counttz_fail2.c
+++ b/test/bits/counttz_fail2.c
@@ -1,0 +1,44 @@
+#include "smack.h"
+#include <stdint.h>
+
+// @expect error
+
+uint32_t cttz32(uint32_t x)
+{
+  uint32_t n = 0; /* number of bits */
+
+  if (!(x & 0x0000FFFF)) { n += 16; x >>= 16; }
+  if (!(x & 0x000000FF)) { n +=  8; x >>=  8; }
+  if (!(x & 0x0000000F)) { n +=  4; x >>=  4; }
+  if (!(x & 0x00000003)) { n +=  2; x >>=  2; }
+
+  n += (x & 1) ^ 1;
+
+  return n;
+}
+
+uint64_t cttz64(uint64_t x)
+{
+  uint64_t n = 0; /* number of bits */
+
+  if (!(x & 0x00000000FFFFFFFF)) { n += 32; x >>= 32; }
+  if (!(x & 0x000000000000FFFF)) { n += 16; x >>= 16; }
+  if (!(x & 0x00000000000000FF)) { n +=  8; x >>=  8; }
+  if (!(x & 0x000000000000000F)) { n +=  4; x >>=  4; }
+  if (!(x & 0x0000000000000003)) { n +=  2; x >>=  2; }
+
+  n += (x & 1) ^ 1;
+
+  return n;
+}
+
+int main(void) {
+  uint32_t x32 = __VERIFIER_nondet_unsigned_int();
+  uint64_t x64 = __VERIFIER_nondet_unsigned_long_long();
+  // This is expected to fail since clang appears to set
+  // the is_zer_undef flag on x86, so zero input values
+  // can be undefined.
+  assert(__builtin_ctz(x32) == cttz32(x32) ||
+         __builtin_ctzll(x64) == cttz64(x64));
+  return 0;
+}


### PR DESCRIPTION
This pull request aims to add several of the LLVM bit-wise intrinsics such as count leading zeros.
Optionally, we can add vectorized versions of these operations as well.
- [x] bswap - Already in develop - here for completeness.
- [x] bitreverse
- [x] ctlz
- [x] ctpop
- [x] cttz
- [x] ~~fshl~~ Not available in LLVM 4
- [x] ~~fshr~~

I think we should focus on those that have been seen in real programs such as ctlz, and those that are easy to generate the intrinsic through compiler builtins.

This is intended to be merged after the `improve-prelude` pull request since there is some functionality I want to use.