### PR TITLE
Minor fix of Prelude.cpp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
       - unzip
       - libz-dev
       - libedit-dev
+      - gcc-multilib
 
 cache:
   directories:

--- a/test/bits/pointer_memops.c
+++ b/test/bits/pointer_memops.c
@@ -1,0 +1,18 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @expect verified
+// @flag --clang-options=-m32 --bit-precise-pointers
+
+int* a[2];
+
+int main(void) {
+  int b = 1;
+  int** c = (int**)malloc(sizeof(int*));
+  a[0] = &b;
+  a[1] = &b;
+  *c = a[0];
+  assert(**c == 1);
+  assert(*a[1] == 1);
+  return 0;
+}

--- a/test/bits/pointer_memops_fail.c
+++ b/test/bits/pointer_memops_fail.c
@@ -1,0 +1,18 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @expect error
+// @flag --clang-options=-m32 --bit-precise-pointers
+
+int* a[2];
+
+int main(void) {
+  int b = 1;
+  int** c = (int**)malloc(sizeof(int*));
+  a[0] = &b;
+  a[1] = &b;
+  *c = a[0];
+  assert(**c == 1);
+  assert(*a[1] != 1);
+  return 0;
+}


### PR DESCRIPTION
This commit fixes the declarations of load/store functions as follows,

1. type-safe load/store functions should always be generated.
2. type-unsafe load/store functions are generated according to the pointer size.