### PR TITLE
Remove duplicate conditional AST node

### DIFF
--- a/include/smack/BoogieAst.h
+++ b/include/smack/BoogieAst.h
@@ -22,9 +22,9 @@ public:
   static const Expr *forall(std::list<Binding>, const Expr *e);
   static const Expr *and_(const Expr *l, const Expr *r);
   static const Expr *or_(const Expr *l, const Expr *r);
-  static const Expr *cond(const Expr *c, const Expr *t, const Expr *e);
   static const Expr *eq(const Expr *l, const Expr *r);
   static const Expr *lt(const Expr *l, const Expr *r);
+  static const Expr *ifThenElse(const Expr *c, const Expr *t, const Expr *e);
   static const Expr *fn(std::string f, const Expr *x);
   static const Expr *fn(std::string f, const Expr *x, const Expr *y);
   static const Expr *fn(std::string f, const Expr *x, const Expr *y,
@@ -48,7 +48,6 @@ public:
   static const Expr *sel(const Expr *b, const Expr *i);
   static const Expr *sel(std::string b, std::string i);
   static const Expr *upd(const Expr *b, const Expr *i, const Expr *v);
-  static const Expr *if_then_else(const Expr *c, const Expr *t, const Expr *e);
   static const Expr *bvExtract(const Expr *v, const Expr *upper,
                                const Expr *lower);
   static const Expr *bvExtract(std::string v, unsigned upper, unsigned lower);
@@ -86,17 +85,6 @@ private:
 public:
   BinExpr(const Binary b, const Expr *l, const Expr *r)
       : op(b), lhs(l), rhs(r) {}
-  void print(std::ostream &os) const;
-};
-
-class CondExpr : public Expr {
-  const Expr *cond;
-  const Expr *then;
-  const Expr *else_;
-
-public:
-  CondExpr(const Expr *c, const Expr *t, const Expr *e)
-      : cond(c), then(t), else_(e) {}
   void print(std::ostream &os) const;
 };
 
@@ -247,12 +235,12 @@ public:
 
 class IfThenElseExpr : public Expr {
   const Expr *cond;
-  const Expr *true_value;
-  const Expr *false_value;
+  const Expr *trueValue;
+  const Expr *falseValue;
 
 public:
   IfThenElseExpr(const Expr *c, const Expr *t, const Expr *e)
-      : cond(c), true_value(t), false_value(e) {}
+      : cond(c), trueValue(t), falseValue(e) {}
   void print(std::ostream &os) const;
 };
 

--- a/lib/smack/BoogieAst.cpp
+++ b/lib/smack/BoogieAst.cpp
@@ -28,16 +28,16 @@ const Expr *Expr::or_(const Expr *l, const Expr *r) {
   return new BinExpr(BinExpr::Or, l, r);
 }
 
-const Expr *Expr::cond(const Expr *c, const Expr *t, const Expr *e) {
-  return new CondExpr(c, t, e);
-}
-
 const Expr *Expr::eq(const Expr *l, const Expr *r) {
   return new BinExpr(BinExpr::Eq, l, r);
 }
 
 const Expr *Expr::lt(const Expr *l, const Expr *r) {
   return new BinExpr(BinExpr::Lt, l, r);
+}
+
+const Expr *Expr::ifThenElse(const Expr *c, const Expr *t, const Expr *e) {
+  return new IfThenElseExpr(c, t, e);
 }
 
 const Expr *Expr::fn(std::string f, std::list<const Expr *> args) {
@@ -113,10 +113,6 @@ const Expr *Expr::sel(std::string b, std::string i) {
 
 const Expr *Expr::upd(const Expr *b, const Expr *i, const Expr *v) {
   return new UpdExpr(b, i, v);
-}
-
-const Expr *Expr::if_then_else(const Expr *c, const Expr *t, const Expr *e) {
-  return new IfThenElseExpr(c, t, e);
 }
 
 const Expr *Expr::bvExtract(const Expr *v, const Expr *u, const Expr *l) {
@@ -424,10 +420,6 @@ void BinExpr::print(std::ostream &os) const {
   os << " " << rhs << ")";
 }
 
-void CondExpr::print(std::ostream &os) const {
-  os << "(if " << cond << " then " << then << " else " << else_ << ")";
-}
-
 void FunExpr::print(std::ostream &os) const {
   os << fun;
   print_seq<const Expr *>(os, args, "(", ", ", ")");
@@ -510,7 +502,8 @@ void CodeExpr::print(std::ostream &os) const {
 }
 
 void IfThenElseExpr::print(std::ostream &os) const {
-  os << "if " << cond << " then " << true_value << " else " << false_value;
+  os << "(if " << cond << " then " << trueValue << " else " << falseValue
+     << ")";
 }
 
 void BvExtract::print(std::ostream &os) const {

--- a/lib/smack/Prelude.cpp
+++ b/lib/smack/Prelude.cpp
@@ -343,7 +343,7 @@ struct IntOpGen::IntArithOp : public IntOp {
   static const Expr *bvMinMaxExpr(unsigned size) {
     std::string signLetter = SIGN ? "s" : "u";
     std::string pred = MIN ? "lt" : "gt";
-    return Expr::if_then_else(
+    return Expr::ifThenElse(
         Expr::fn(indexedName("$" + signLetter + pred,
                              {getBvTypeName(size), Naming::BOOL_TYPE}),
                  makeIntVarExprs(2)),
@@ -356,7 +356,7 @@ struct IntOpGen::IntArithOp : public IntOp {
     const Expr *a1 = makeIntVarExpr(1);
     const Expr *a2 = makeIntVarExpr(2);
     auto pred = MIN ? Expr::lt(a1, a2) : Expr::lt(a2, a1);
-    return Expr::if_then_else(pred, a1, a2);
+    return Expr::ifThenElse(pred, a1, a2);
   }
 };
 
@@ -465,12 +465,11 @@ struct IntOpGen::IntPred : public IntOp {
                   Naming::BOOL_TYPE, ((IntOp::exprT)iop->func)(size));
     // e.g.: function {:inline} $ule.i1(i1: i1, i2: i1) returns (i1)
     //        { if $ule.i1.bool(i1, i2) then 1 else 0 }
-    auto predFunc =
-        inlinedOp(name, {type}, makeIntVars(2, type), getIntTypeName(1),
-                  Expr::if_then_else(
-                      Expr::fn(indexedName(name, {type, Naming::BOOL_TYPE}),
-                               makeIntVarExprs(2)),
-                      Expr::lit(1ll), Expr::lit(0ll)));
+    auto predFunc = inlinedOp(
+        name, {type}, makeIntVars(2, type), getIntTypeName(1),
+        Expr::ifThenElse(Expr::fn(indexedName(name, {type, Naming::BOOL_TYPE}),
+                                  makeIntVarExprs(2)),
+                         Expr::lit(1ll), Expr::lit(0ll)));
     return {compFunc, predFunc};
   }
 
@@ -494,12 +493,11 @@ struct IntOpGen::IntPred : public IntOp {
       llvm_unreachable("no uninterpreted bv predicates");
     // e.g.: function {:inline} $ule.bv1(i1: bv1, i2: bv1) returns (bv1)
     //        { if $ule.bv1.bool(i1, i2) then 1bv1 else 0bv1 }
-    predFunc =
-        inlinedOp(name, {type}, makeIntVars(2, type), getBvTypeName(1),
-                  Expr::if_then_else(
-                      Expr::fn(indexedName(name, {type, Naming::BOOL_TYPE}),
-                               makeIntVarExpr(1), makeIntVarExpr(2)),
-                      Expr::lit(1, 1), Expr::lit(0, 1)));
+    predFunc = inlinedOp(
+        name, {type}, makeIntVars(2, type), getBvTypeName(1),
+        Expr::ifThenElse(Expr::fn(indexedName(name, {type, Naming::BOOL_TYPE}),
+                                  makeIntVarExpr(1), makeIntVarExpr(2)),
+                         Expr::lit(1, 1), Expr::lit(0, 1)));
     return {compFunc, predFunc};
   }
 
@@ -744,11 +742,12 @@ void IntOpGen::generateBvIntConvs(std::stringstream &s) const {
       llvm_unreachable("Unexpected pointer bit width.");
     s << Decl::function(
              indexedName("$bv2int", {ptrSize}), {{"i", bt}}, it,
-             Expr::cond(Expr::fn(indexedName("$slt", {bt, Naming::BOOL_TYPE}),
-                                 {arg, Expr::lit(0ULL, ptrSize)}),
-                        Expr::fn(indexedName("$sub", {it}),
-                                 {uint, Expr::lit(offset, 0U)}),
-                        uint),
+             Expr::ifThenElse(
+                 Expr::fn(indexedName("$slt", {bt, Naming::BOOL_TYPE}),
+                          {arg, Expr::lit(0ULL, ptrSize)}),
+                 Expr::fn(indexedName("$sub", {it}),
+                          {uint, Expr::lit(offset, 0U)}),
+                 uint),
              {makeInlineAttr()})
       << "\n";
   } else
@@ -927,11 +926,12 @@ void PtrOpGen::generatePreds(std::stringstream &s) const {
              indexedName(pred, {Naming::PTR_TYPE}),
              {{"p1", Naming::PTR_TYPE}, {"p2", Naming::PTR_TYPE}},
              prelude.rep.intType(1),
-             Expr::cond(Expr::fn(indexedName(pred, {prelude.rep.pointerType(),
-                                                    Naming::BOOL_TYPE}),
-                                 {Expr::id("p1"), Expr::id("p2")}),
-                        prelude.rep.integerLit(1LL, 1),
-                        prelude.rep.integerLit(0LL, 1)),
+             Expr::ifThenElse(
+                 Expr::fn(indexedName(pred, {prelude.rep.pointerType(),
+                                             Naming::BOOL_TYPE}),
+                          {Expr::id("p1"), Expr::id("p2")}),
+                 prelude.rep.integerLit(1LL, 1),
+                 prelude.rep.integerLit(0LL, 1)),
              {makeInlineAttr()})
       << "\n";
     s << Decl::function(

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -539,7 +539,8 @@ void SmackInstGenerator::visitAtomicCmpXchgInst(llvm::AtomicCmpXchgInst &i) {
   const Expr *cmp = rep->expr(i.getOperand(1));
   const Expr *swp = rep->expr(i.getOperand(2));
   emit(Stmt::assign(res, mem));
-  emit(rep->store(i.getOperand(0), Expr::cond(Expr::eq(mem, cmp), swp, mem)));
+  emit(rep->store(i.getOperand(0),
+                  Expr::ifThenElse(Expr::eq(mem, cmp), swp, mem)));
 }
 
 void SmackInstGenerator::visitAtomicRMWInst(llvm::AtomicRMWInst &i) {
@@ -623,7 +624,7 @@ void SmackInstGenerator::visitSelectInst(llvm::SelectInst &i) {
          "Vector condition is not supported.");
   emit(Stmt::assign(
       Expr::id(x),
-      Expr::if_then_else(Expr::eq(c, rep->integerLit(1LL, 1)), v1, v2)));
+      Expr::ifThenElse(Expr::eq(c, rep->integerLit(1LL, 1)), v1, v2)));
 }
 
 void SmackInstGenerator::visitCallInst(llvm::CallInst &ci) {
@@ -718,7 +719,7 @@ void SmackInstGenerator::visitCallInst(llvm::CallInst &ci) {
     //   args.push_back(Expr::id(m.first));
     // auto E = Expr::fn(F->getName(), args);
     // emit(Stmt::assign(rep->expr(&ci),
-    //   Expr::cond(Expr::forall(binding, "int", E),
+    //   Expr::ifThenElse(Expr::forall(binding, "int", E),
     //     rep->integerLit(1U,1), rep->integerLit(0U,1))));
 
   } else if (name == Naming::CONTRACT_REQUIRES ||
@@ -1021,7 +1022,7 @@ void SmackInstGenerator::visitIntrinsicInst(llvm::IntrinsicInst &ii) {
         // ... else if v[1:0] == 1 then 31bv32 else 32bv32
         const Expr *body = Expr::lit(width, width);
         for (unsigned i = 0; i < width; ++i) {
-          body = Expr::if_then_else(
+          body = Expr::ifThenElse(
               Expr::eq(Expr::bvExtract(var, i + 1, i), Expr::lit(1, 1)),
               Expr::lit(width - i - 1, width), body);
         }
@@ -1030,11 +1031,11 @@ void SmackInstGenerator::visitIntrinsicInst(llvm::IntrinsicInst &ii) {
         // argument
         // is zero, then the result is undefined.
         auto isZeroUndef = rep->expr(ci->getArgOperand(1));
-        body = Expr::if_then_else(
-            Expr::and_(Expr::eq(isZeroUndef, Expr::lit(1, 1)),
-                       Expr::eq(var, Expr::lit(0, width))),
-            rep->expr(ci), // The result is undefined
-            body);
+        body =
+            Expr::ifThenElse(Expr::and_(Expr::eq(isZeroUndef, Expr::lit(1, 1)),
+                                        Expr::eq(var, Expr::lit(0, width))),
+                             rep->expr(ci), // The result is undefined
+                             body);
         emit(Stmt::havoc(rep->expr(ci)));
         emit(Stmt::assign(rep->expr(ci), body));
       },
@@ -1050,7 +1051,7 @@ void SmackInstGenerator::visitIntrinsicInst(llvm::IntrinsicInst &ii) {
         // ... else if v[32:31] == 1 then 31bv32 else 32bv32
         const Expr *body = Expr::lit(width, width);
         for (unsigned i = width; i > 0; --i) {
-          body = Expr::if_then_else(
+          body = Expr::ifThenElse(
               Expr::eq(Expr::bvExtract(arg, i, i - 1), Expr::lit(1, 1)),
               Expr::lit(i - 1, width), body);
         }
@@ -1059,11 +1060,11 @@ void SmackInstGenerator::visitIntrinsicInst(llvm::IntrinsicInst &ii) {
         // argument
         // is zero, then the result is undefined.
         auto isZeroUndef = rep->expr(ci->getArgOperand(1));
-        body = Expr::if_then_else(
-            Expr::and_(Expr::eq(isZeroUndef, Expr::lit(1, 1)),
-                       Expr::eq(arg, Expr::lit(0, width))),
-            rep->expr(ci), // The result is undefined
-            body);
+        body =
+            Expr::ifThenElse(Expr::and_(Expr::eq(isZeroUndef, Expr::lit(1, 1)),
+                                        Expr::eq(arg, Expr::lit(0, width))),
+                             rep->expr(ci), // The result is undefined
+                             body);
         emit(Stmt::havoc(rep->expr(ci)));
         emit(Stmt::assign(rep->expr(ci), body));
       },

--- a/lib/smack/SmackRep.cpp
+++ b/lib/smack/SmackRep.cpp
@@ -937,8 +937,8 @@ const Expr *SmackRep::cmp(unsigned predicate, const llvm::Value *lhs,
   const Expr *e1 = expr(lhs, isUnsigned);
   const Expr *e2 = expr(rhs, isUnsigned);
   if (lhs->getType()->isFloatingPointTy())
-    return Expr::if_then_else(Expr::fn(fn + ".bool", e1, e2),
-                              integerLit(1ULL, 1), integerLit(0ULL, 1));
+    return Expr::ifThenElse(Expr::fn(fn + ".bool", e1, e2), integerLit(1ULL, 1),
+                            integerLit(0ULL, 1));
   else
     return Expr::fn(fn, e1, e2);
 }

--- a/test/basic/select.c
+++ b/test/basic/select.c
@@ -1,7 +1,7 @@
 #include "smack.h"
 
 // @expect verified
-// @checkbpl grep -E ":= if.+then.+else.+"
+// @checkbpl grep -E ":= \(if.+then.+else.+\)"
 
 int main(void) {
   int c = 2;

--- a/test/basic/select_fail.c
+++ b/test/basic/select_fail.c
@@ -1,7 +1,7 @@
 #include "smack.h"
 
 // @expect error
-// @checkbpl grep -E ":= if.+then.+else.+"
+// @checkbpl grep -E ":= \(if.+then.+else.+\)"
 
 int main(void) {
   int c = 2;


### PR DESCRIPTION
This removes the `CondExpr` class in favor of the more descriptively named `IfThenElseExpr` class. The printing of `IfThenElseExpr` now encloses the expression in parentheses to prevent precedence issues.