### PR TITLE
Remove patched `pointer_iterator`

### DIFF
--- a/include/dsa/DSGraphTraits.h
+++ b/include/dsa/DSGraphTraits.h
@@ -17,38 +17,13 @@
 #define LLVM_ANALYSIS_DSGRAPHTRAITS_H
 
 #include "dsa/DSGraph.h"
+#include "llvm/ADT/iterator.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/STLExtras.h"
 
 #include <iterator>
 
 namespace llvm {
-
-namespace bugfix {
-
-// XXX: There's a bug in llvm::pointer_iterator. The iterator_category
-// parameter to iterator_adaptor_base is omitted. We can remove this once it is fixed.
-// http://llvm.org/doxygen/iterator_8h_source.html#l00311
-template <typename WrappedIteratorT,
-          typename T = decltype(&*std::declval<WrappedIteratorT>())>
-class pointer_iterator
-    : public iterator_adaptor_base<pointer_iterator<WrappedIteratorT, T>,
-                                   WrappedIteratorT,
-                                   typename std::iterator_traits<WrappedIteratorT>::iterator_category,
-                                   T> {
-  mutable T Ptr;
-
-public:
-  pointer_iterator() = default;
-
-  explicit pointer_iterator(WrappedIteratorT u)
-      : pointer_iterator::iterator_adaptor_base(std::move(u)) {}
-
-  T &operator*() { return Ptr = &*this->I; }
-  const T &operator*() const { return Ptr = &*this->I; }
-};
-
-} // End bugfix namespace
 
 template<typename NodeTy>
 class DSNodeIterator : public std::iterator<std::forward_iterator_tag, const DSNode, ptrdiff_t> {
@@ -128,7 +103,7 @@ template <> struct GraphTraits<const DSGraph*> {
   typedef DSNode::const_iterator ChildIteratorType;
 
   // nodes_iterator/begin/end - Allow iteration over all nodes in the graph
-  typedef bugfix::pointer_iterator<DSGraph::node_const_iterator> nodes_iterator;
+  typedef pointer_iterator<DSGraph::node_const_iterator> nodes_iterator;
   static nodes_iterator nodes_begin(const DSGraph *G) {
     return nodes_iterator(G->node_begin());
   }


### PR DESCRIPTION
This fix was [merged upstream](https://reviews.llvm.org/D54377#1298014) and (I think) released in LLVM 7.0.1. 