### PR TITLE
Fixed over-collapsing of regions when malloc is encountered

### DIFF
--- a/lib/smack/Regions.cpp
+++ b/lib/smack/Regions.cpp
@@ -347,9 +347,6 @@ void Regions::visitCallInst(CallInst &I) {
   Function *F = I.getCalledFunction();
   std::string name = F && F->hasName() ? F->getName().str() : "";
 
-  if (I.getType()->isPointerTy())
-    idx(&I);
-
   if (name.find("__SMACK_values") != std::string::npos) {
     assert(I.getNumArgOperands() == 2 && "Expected two operands.");
     const Value *P = I.getArgOperand(0);

--- a/lib/smack/Regions.cpp
+++ b/lib/smack/Regions.cpp
@@ -347,6 +347,9 @@ void Regions::visitCallInst(CallInst &I) {
   Function *F = I.getCalledFunction();
   std::string name = F && F->hasName() ? F->getName().str() : "";
 
+  if (F && F->isDeclaration() && I.getType()->isPointerTy() && name != "malloc")
+    idx(&I);
+
   if (name.find("__SMACK_values") != std::string::npos) {
     assert(I.getNumArgOperands() == 2 && "Expected two operands.");
     const Value *P = I.getArgOperand(0);

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -798,9 +798,9 @@ void SmackInstGenerator::visitCallInst(llvm::CallInst &ci) {
     emit(rep->call(f, ci));
   }
 
-  if (f->isDeclaration() && rep->isExternal(&ci)) {
+  if (f->isDeclaration()) {
     std::string name = naming->get(*f);
-    if (!EXTERNAL_PROC_IGNORE.match(name))
+    if (!EXTERNAL_PROC_IGNORE.match(name) && rep->isExternal(&ci))
       emit(Stmt::assume(Expr::fn(Naming::EXTERNAL_ADDR, rep->expr(&ci))));
   }
 

--- a/test/c/basic/malloc_collapsing.c
+++ b/test/c/basic/malloc_collapsing.c
@@ -1,0 +1,14 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @expect verified
+// @checkbpl grep "var \$M.0: \[ref\] i32;"
+
+int main(void) {
+  int *p = (int *)malloc(sizeof(int));
+  *p = 2;
+  p = (int *)realloc(p, sizeof(int));
+  *p = 1;
+  assert(*p != 2);
+  return *p;
+}


### PR DESCRIPTION
In order to establish whether a pointer returned from an external
function can alias program-allocated memory, we used to generate
regions for return values of pointer types of all functions. We
used to do that no matter how the pointers would end up being used.
In the case of malloc, this would almost always lead to collapsing
of regions since malloc returns a pointer of type i8, but is
almost always cast into the appropriate type and then used.
This fix removes this behavior and avoids collapsing of regions
due to malloc.

Fixes #473