### PR TITLE
Fixed compilation warning that assert was causing

### DIFF
--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -58,8 +58,13 @@ void __VERIFIER_assert(int);
 void __VERIFIER_error(void);
 
 #ifndef AVOID_NAME_CONFLICTS
-#define assert(EX) __VERIFIER_assert(EX)
-#define assume(EX) __VERIFIER_assume(EX)
+#define assert(EX) do {\
+  if (!(EX)) __VERIFIER_assert(0);\
+} while (0)
+
+#define assume(EX) do {\
+  if (!(EX)) __VERIFIER_assume(0);\
+} while (0)
 #endif
 
 #define S4(a, b, c, d) a b c d

--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -58,13 +58,16 @@ void __VERIFIER_assert(int);
 void __VERIFIER_error(void);
 
 #ifndef AVOID_NAME_CONFLICTS
-#define assert(EX) do {\
-  if (!(EX)) __VERIFIER_assert(0);\
-} while (0)
-
-#define assume(EX) do {\
-  if (!(EX)) __VERIFIER_assume(0);\
-} while (0)
+#define assert(EX)                                                             \
+  do {                                                                         \
+    if (!(EX))                                                                 \
+      __VERIFIER_assert(0);                                                    \
+  } while (0)
+#define assume(EX)                                                             \
+  do {                                                                         \
+    if (!(EX))                                                                 \
+      __VERIFIER_assume(0);                                                    \
+  } while (0)
 #endif
 
 #define S4(a, b, c, d) a b c d

--- a/test/c/basic/select.c
+++ b/test/c/basic/select.c
@@ -3,9 +3,7 @@
 // @expect verified
 // @checkbpl grep -E ":= \(if.+then.+else.+\)"
 
-void foo(int x) {
-  assert(x);
-}
+void foo(int x) { assert(x); }
 
 int main(void) {
   int c = __VERIFIER_nondet_int();

--- a/test/c/basic/select.c
+++ b/test/c/basic/select.c
@@ -3,7 +3,12 @@
 // @expect verified
 // @checkbpl grep -E ":= \(if.+then.+else.+\)"
 
+void foo(int x) {
+  assert(x);
+}
+
 int main(void) {
-  int c = 2;
-  assert(c == 2 ? 1 : 0);
+  int c = __VERIFIER_nondet_int();
+  assume(c == 2);
+  foo(c == 2 ? 1 : 0);
 }

--- a/test/c/basic/select_fail.c
+++ b/test/c/basic/select_fail.c
@@ -3,7 +3,12 @@
 // @expect error
 // @checkbpl grep -E ":= \(if.+then.+else.+\)"
 
+void foo(int x) {
+  assert(x);
+}
+
 int main(void) {
-  int c = 2;
-  assert(c != 2 ? 1 : 0);
+  int c = __VERIFIER_nondet_int();
+  assume(c == 2);
+  foo(c != 2 ? 1 : 0);
 }

--- a/test/c/basic/select_fail.c
+++ b/test/c/basic/select_fail.c
@@ -3,9 +3,7 @@
 // @expect error
 // @checkbpl grep -E ":= \(if.+then.+else.+\)"
 
-void foo(int x) {
-  assert(x);
-}
+void foo(int x) { assert(x); }
 
 int main(void) {
   int c = __VERIFIER_nondet_int();

--- a/test/c/ntdrivers/floppy2_true.i.cil.c
+++ b/test/c/ntdrivers/floppy2_true.i.cil.c
@@ -6803,7 +6803,7 @@ NTSTATUS FlQueueIrpToThread(PIRP Irp, PDISKETTE_EXTENSION DisketteExtension) {
     } else {
       {
 #line 949
-        __VERIFIER_assert(0);
+        assert(0);
       }
     }
     {
@@ -7643,7 +7643,7 @@ NTSTATUS FloppyDeviceControl(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
         } else {
           {
 #line 1098
-            __VERIFIER_assert(0);
+            assert(0);
           }
         }
         {
@@ -9322,7 +9322,7 @@ NTSTATUS FloppyDeviceControl(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
                                   } else {
                                     {
 #line 1534
-                                      __VERIFIER_assert(0);
+                                      assert(0);
                                     }
                                   }
                                   {
@@ -10108,7 +10108,7 @@ NTSTATUS FloppyPnp(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
                             } else {
                               {
 #line 1627
-                                __VERIFIER_assert(0);
+                                assert(0);
                               }
                             }
                             {
@@ -10291,7 +10291,7 @@ NTSTATUS FloppyPnp(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
                           } else {
                             {
 #line 1673
-                              __VERIFIER_assert(0);
+                              assert(0);
                             }
                           }
                           {
@@ -10446,7 +10446,7 @@ NTSTATUS FloppyPnp(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
                             } else {
                               {
 #line 1707
-                                __VERIFIER_assert(0);
+                                assert(0);
                               }
                             }
                             {
@@ -10593,14 +10593,14 @@ NTSTATUS FloppyPnp(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
                             if (s != 1) {
                               {
 #line 1733
-                                __VERIFIER_assert(0);
+                                assert(0);
                               }
                             } else {
 #line 1735
                               if (compRegistered != 0) {
                                 {
 #line 1735
-                                  __VERIFIER_assert(0);
+                                  assert(0);
                                 }
                               } else {
 #line 1737
@@ -10819,7 +10819,7 @@ NTSTATUS FloppyPnp(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
                         } else {
                           {
 #line 1785
-                            __VERIFIER_assert(0);
+                            assert(0);
                           }
                         }
                         {
@@ -10943,7 +10943,7 @@ NTSTATUS FloppyPnp(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
                         } else {
                           {
 #line 1820
-                            __VERIFIER_assert(0);
+                            assert(0);
                           }
                         }
                         {
@@ -11186,7 +11186,7 @@ NTSTATUS FloppyPnp(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
                         } else {
                           {
 #line 1863
-                            __VERIFIER_assert(0);
+                            assert(0);
                           }
                         }
                         {
@@ -11645,14 +11645,14 @@ NTSTATUS FloppyStartDevice(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
     if (s != 1) {
       {
 #line 1904
-        __VERIFIER_assert(0);
+        assert(0);
       }
     } else {
 #line 1906
       if (compRegistered != 0) {
         {
 #line 1906
-          __VERIFIER_assert(0);
+          assert(0);
         }
       } else {
 #line 1908
@@ -12679,7 +12679,7 @@ NTSTATUS FloppyPower(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
     } else {
       {
 #line 2169
-        __VERIFIER_assert(0);
+        assert(0);
       }
     }
     {
@@ -29275,7 +29275,7 @@ NTSTATUS FloppyQueueRequest(PDISKETTE_EXTENSION DisketteExtension, PIRP Irp) {
           } else {
             {
 #line 6362
-              __VERIFIER_assert(0);
+              assert(0);
             }
           }
           {
@@ -30224,7 +30224,7 @@ int main(void) {
                     if (status == 259L) {
                       {
 #line 207
-                        __VERIFIER_assert(0);
+                        assert(0);
                       }
                     } else {
                     }
@@ -30236,7 +30236,7 @@ int main(void) {
                       if (status != __cil_tmp23) {
                         {
 #line 209
-                          __VERIFIER_assert(0);
+                          assert(0);
                         }
                       } else {
                       }
@@ -30870,7 +30870,7 @@ void stubMoreProcessingRequired(void) {
     } else {
       {
 #line 599
-        __VERIFIER_assert(0);
+        assert(0);
       }
     }
 #line 602
@@ -30977,7 +30977,7 @@ NTSTATUS(__attribute__((__fastcall__)) IofCallDriver)
         } else {
           {
 #line 640
-            __VERIFIER_assert(0);
+            assert(0);
           }
         }
       }
@@ -31001,7 +31001,7 @@ void(__attribute__((__fastcall__)) IofCompleteRequest)(PIRP Irp,
     } else {
       {
 #line 674
-        __VERIFIER_assert(0);
+        assert(0);
       }
     }
 #line 677
@@ -31153,7 +31153,7 @@ NTSTATUS KeWaitForSingleObject(PVOID Object, KWAIT_REASON WaitReason,
         if (s == 6) {
           {
 #line 794
-            __VERIFIER_assert(0);
+            assert(0);
           }
         } else {
         }

--- a/test/c/special/assume.c
+++ b/test/c/special/assume.c
@@ -8,5 +8,5 @@ int main(void) {
   // This assumption is used for verification, even though bit-precise
   // is not enabled, the assertion will pass.
   __builtin_assume((y & 1) == 0);
-  __VERIFIER_assert((y & 1) == 0);
+  assert((y & 1) == 0);
 }

--- a/test/c/special/assume2.c
+++ b/test/c/special/assume2.c
@@ -8,5 +8,5 @@ int main(void) {
   // This assumption is used for verification, even though the assumption
   // is false, the assertion will pass.
   __builtin_assume((y & 1) == 0);
-  __VERIFIER_assert((y & 1) == 0);
+  assert((y & 1) == 0);
 }

--- a/test/c/special/assume_check.c
+++ b/test/c/special/assume_check.c
@@ -8,5 +8,5 @@ int main(void) {
   unsigned int y = 2 * (unsigned int)__VERIFIER_nondet_unsigned_short();
   // This assumption is checked under bit-precise and is verified.
   __builtin_assume((y & 1) == 0);
-  __VERIFIER_assert((y & 1) == 0);
+  assert((y & 1) == 0);
 }

--- a/test/c/special/assume_check2.c
+++ b/test/c/special/assume_check2.c
@@ -9,5 +9,5 @@ int main(void) {
   // This assumption is checked at verification time, and since bit-precise
   // is enabled, and y is clearly odd, the check will pass.
   __builtin_assume((y & 1) == 1);
-  __VERIFIER_assert((y & 1) == 1);
+  assert((y & 1) == 1);
 }

--- a/test/c/special/assume_check_fail.c
+++ b/test/c/special/assume_check_fail.c
@@ -9,5 +9,5 @@ int main(void) {
   // This assumption is checked at verification time, and since bit-precise
   // is enabled, and y is clearly odd, the assumption should be shown false.
   __builtin_assume((y & 1) == 0);
-  __VERIFIER_assert((y & 1) == 0);
+  assert((y & 1) == 0);
 }

--- a/test/c/special/assume_fail.c
+++ b/test/c/special/assume_fail.c
@@ -8,5 +8,5 @@ int main(void) {
   // This assumption is not used, and since bit-precise is not enabled,
   // verification will fail.
   __builtin_assume((y & 1) == 0);
-  __VERIFIER_assert((y & 1) == 0);
+  assert((y & 1) == 0);
 }


### PR DESCRIPTION
Assert was causing a compilation warning since it used to expand
into `__VERIFIER_assert` directly. This is now fixed by wrapping
it with an if condition.