### PR TITLE
Fix smack pthread.c when using --bit-precise

### DIFF
--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -78,6 +78,7 @@ def default_clang_compile_command(args, lib = False):
   if args.memory_safety: cmd += ['-DMEMORY_SAFETY']
   if args.integer_overflow: cmd += (['-fsanitize=signed-integer-overflow,shift'] if not lib else ['-DSIGNED_INTEGER_OVERFLOW_CHECK'])
   if args.float: cmd += ['-DFLOAT_ENABLED']
+  if args.bit_precise: cmd += ['-DBIT_PRECISE']
   if sys.stdout.isatty(): cmd += ['-fcolor-diagnostics']
   return cmd
 

--- a/share/smack/lib/pthread.c
+++ b/share/smack/lib/pthread.c
@@ -4,10 +4,16 @@
 #include "pthread.h"
 #include "smack.h"
 
+#if BIT_PRECISE
+#define TID_TYPE "bv32"
+#else
+#define TID_TYPE "int"
+#endif
+
 void __SMACK_init_func_corral_primitives() {
   // Declare these, so bpl parsing doesn't complain
-  __SMACK_top_decl("procedure corral_getThreadID() returns (x:int);");
-  __SMACK_top_decl("procedure corral_getChildThreadID() returns (x:int);");
+  __SMACK_top_decl("procedure corral_getThreadID() returns (x:"TID_TYPE");");
+  __SMACK_top_decl("procedure corral_getChildThreadID() returns (x:"TID_TYPE");");
   __SMACK_top_decl("procedure corral_atomic_begin();");
   __SMACK_top_decl("procedure corral_atomic_end();");
 }
@@ -15,14 +21,14 @@ void __SMACK_init_func_corral_primitives() {
 void __SMACK_init_func_thread() {
   // Array and possible statuses for tracking pthreads
   __SMACK_top_decl("//dim0=tid, dim1= idx 0 gets status, 1 gets return value");
-  __SMACK_top_decl("var $pthreadStatus: [int][int]int;");
+  __SMACK_top_decl("var $pthreadStatus: ["TID_TYPE"][int]int;");
   __SMACK_top_decl("const unique $pthread_uninitialized: int;");
   __SMACK_top_decl("const unique $pthread_initialized: int;");
   __SMACK_top_decl("const unique $pthread_waiting: int;");
   __SMACK_top_decl("const unique $pthread_running: int;");
   __SMACK_top_decl("const unique $pthread_stopped: int;");
   // Initialize this array so all threads begin as uninitialized
-  __SMACK_code("assume (forall i:int :: $pthreadStatus[i][0] == "
+  __SMACK_code("assume (forall i:"TID_TYPE" :: $pthreadStatus[i][0] == "
                "$pthread_uninitialized);");
 }
 

--- a/share/smack/lib/pthread.c
+++ b/share/smack/lib/pthread.c
@@ -4,16 +4,18 @@
 #include "pthread.h"
 #include "smack.h"
 
-#if BIT_PRECISE
-#define TID_TYPE "bv32"
+void __SMACK_init_tidtype() {
+#ifdef BIT_PRECISE
+  __SMACK_top_decl("type $tidtype = bv32;");
 #else
-#define TID_TYPE "int"
+  __SMACK_top_decl("type $tidtype = i32;");
 #endif
+}
 
 void __SMACK_init_func_corral_primitives() {
   // Declare these, so bpl parsing doesn't complain
-  __SMACK_top_decl("procedure corral_getThreadID() returns (x:"TID_TYPE");");
-  __SMACK_top_decl("procedure corral_getChildThreadID() returns (x:"TID_TYPE");");
+  __SMACK_top_decl("procedure corral_getThreadID() returns (x:$tidtype);");
+  __SMACK_top_decl("procedure corral_getChildThreadID() returns (x:$tidtype);");
   __SMACK_top_decl("procedure corral_atomic_begin();");
   __SMACK_top_decl("procedure corral_atomic_end();");
 }
@@ -21,14 +23,14 @@ void __SMACK_init_func_corral_primitives() {
 void __SMACK_init_func_thread() {
   // Array and possible statuses for tracking pthreads
   __SMACK_top_decl("//dim0=tid, dim1= idx 0 gets status, 1 gets return value");
-  __SMACK_top_decl("var $pthreadStatus: ["TID_TYPE"][int]int;");
+  __SMACK_top_decl("var $pthreadStatus: [$tidtype][int]int;");
   __SMACK_top_decl("const unique $pthread_uninitialized: int;");
   __SMACK_top_decl("const unique $pthread_initialized: int;");
   __SMACK_top_decl("const unique $pthread_waiting: int;");
   __SMACK_top_decl("const unique $pthread_running: int;");
   __SMACK_top_decl("const unique $pthread_stopped: int;");
   // Initialize this array so all threads begin as uninitialized
-  __SMACK_code("assume (forall i:"TID_TYPE" :: $pthreadStatus[i][0] == "
+  __SMACK_code("assume (forall i:$tidtype :: $pthreadStatus[i][0] == "
                "$pthread_uninitialized);");
 }
 


### PR DESCRIPTION
Fix #520 by switching between Boogie types in `pthread.c`. Previously the file used Boogie int everywhere.