### PR TITLE
Fix #528: memsafe pthread_join stub

### DIFF
--- a/share/smack/lib/pthread.c
+++ b/share/smack/lib/pthread.c
@@ -69,10 +69,13 @@ int pthread_join(pthread_t __th, void **__thread_return) {
   // Get the thread's return value
   void *tmp_thread_return_pointer = (void *)__VERIFIER_nondet_long();
   __SMACK_code("@ := $pthreadStatus[@][1];", tmp_thread_return_pointer, __th);
-  *__thread_return = tmp_thread_return_pointer;
 
-  // Print return pointer value to SMACK traces
-  void *actual_thread_return_pointer = *__thread_return;
+  if (__thread_return) {
+    *__thread_return = tmp_thread_return_pointer;
+
+    // Print return pointer value to SMACK traces
+    void *actual_thread_return_pointer = *__thread_return;
+  }
 
   return 0;
 }

--- a/test/c/pthread/join_null_retval.c
+++ b/test/c/pthread/join_null_retval.c
@@ -1,0 +1,15 @@
+#include "smack.h"
+#include <pthread.h>
+#include <stdlib.h>
+
+// @expect verified
+// @flag --memory-safety
+
+void *t1(void *arg) { return NULL; }
+
+int main(void) {
+  pthread_t tid1;
+  pthread_create(&tid1, 0, t1, 0);
+  pthread_join(tid1, NULL);
+  return 0;
+}


### PR DESCRIPTION
Check for NULL retval parameter before deref