### PR TITLE
Fix issue #498

### DIFF
--- a/test/rust/basic/arith.rs
+++ b/test/rust/basic/arith.rs
@@ -3,7 +3,6 @@ mod smack;
 use smack::*;
 
 // @expect verified
-// @flag --bit-precise
 
 fn main() {
   // unsigned


### PR DESCRIPTION
This PR removed the only place where `--bit-precise` is needed (also unnecessarily). 