### PR TITLE
Change Rust print*! macros to simply evaluate the arguments

### DIFF
--- a/share/smack/lib/smack.rs
+++ b/share/smack/lib/smack.rs
@@ -28,6 +28,31 @@ macro_rules! verifier_assert {
 
 #[cfg(verifier = "smack")]
 #[macro_export]
+macro_rules! print {
+  ($fmt:expr) => ();
+  ($fmt:expr, $($arg:expr),*) => ( $($arg);* )
+}
+
+#[cfg(verifier = "smack")]
+#[macro_export]
+macro_rules! println {
+  ($($arg:tt)*) => ( print!($($arg)*) )
+}
+
+#[cfg(verifier = "smack")]
+#[macro_export]
+macro_rules! eprint {
+  ($($arg:tt)*) => ( print!($($arg)*) )
+}
+
+#[cfg(verifier = "smack")]
+#[macro_export]
+macro_rules! eprintln {
+  ($($arg:tt)*) => ( print!($($arg)*) )
+}
+
+#[cfg(verifier = "smack")]
+#[macro_export]
 macro_rules! assert {
   ( $cond:expr ) => ( verifier_assert!($cond); )
 }

--- a/test/rust/basic/print.rs
+++ b/test/rust/basic/print.rs
@@ -1,0 +1,34 @@
+#[macro_use]
+extern crate smack;
+use smack::*;
+
+// @expect verified
+
+static mut NUM: i32 = 0;
+
+fn incr(x: i32) -> i32 {
+  unsafe {
+    NUM += x;
+    NUM
+  }
+}
+
+fn test_print() {
+  print!("hola");
+  println!("hola");
+  print!("hola, senor {}", incr(1));
+  println!("hola, senor {}", incr(2));
+  print!("hola, senor {0} and senor {1}", 3, incr(3));
+  println!("hola, senor {0} and senor {1}", 4, incr(4));
+  eprint!("hola");
+  eprintln!("hola");
+  eprint!("hola, senor {}", incr(1));
+  eprintln!("hola, senor {}", incr(2));
+  eprint!("hola, senor {0} and senor {1}", 3, incr(3));
+  eprintln!("hola, senor {0} and senor {1}", 4, incr(4));
+}
+
+fn main() {
+  test_print();
+  smack::assert!(NUM == 0 + 2 + 4 + 6 + 8);
+}

--- a/test/rust/basic/print_fail.rs
+++ b/test/rust/basic/print_fail.rs
@@ -1,0 +1,34 @@
+#[macro_use]
+extern crate smack;
+use smack::*;
+
+// @expect error
+
+static mut NUM: i32 = 0;
+
+fn incr(x: i32) -> i32 {
+  unsafe {
+    NUM += x;
+    NUM
+  }
+}
+
+fn test_print() {
+  print!("hola");
+  println!("hola");
+  print!("hola, senor {}", incr(1));
+  println!("hola, senor {}", incr(2));
+  print!("hola, senor {0} and senor {1}", 3, incr(3));
+  println!("hola, senor {0} and senor {1}", 4, incr(4));
+  eprint!("hola");
+  eprintln!("hola");
+  eprint!("hola, senor {}", incr(1));
+  eprintln!("hola, senor {}", incr(2));
+  eprint!("hola, senor {0} and senor {1}", 3, incr(3));
+  eprintln!("hola, senor {0} and senor {1}", 4, incr(4));
+}
+
+fn main() {
+  test_print();
+  smack::assert!(NUM != 0 + 2 + 4 + 6 + 8);
+}


### PR DESCRIPTION
Fixes #579