### PR TITLE
Fix Rust compilation

### DIFF
--- a/test/rust/basic/nondet_defined.rs
+++ b/test/rust/basic/nondet_defined.rs
@@ -1,0 +1,11 @@
+#[macro_use]
+extern crate smack;
+use smack::*;
+
+// @expect verified
+
+fn main() {
+  // Verifies that nondet is defined in the ll file.
+  let a = 6u32.verifier_nondet();
+  verifier_assert!(a >= 0); // a is unsigned
+}


### PR DESCRIPTION
This addresses an issue where Rust programs had `nondet` functions undefined. This is due to LLVM information not being present in the generated `rlib`. This addresses this by compiling `smack.rs` as a `bc` file for linking.