### PR TITLE
Simplified memory safety checking

### DIFF
--- a/include/smack/MemorySafetyChecker.h
+++ b/include/smack/MemorySafetyChecker.h
@@ -14,9 +14,6 @@ namespace smack {
 class MemorySafetyChecker : public llvm::FunctionPass,
                             public llvm::InstVisitor<MemorySafetyChecker> {
 private:
-  std::map<llvm::Module *, llvm::Function *> leakCheckFunction;
-  std::map<llvm::Module *, llvm::Function *> safetyCheckFunction;
-
   llvm::Function *getLeakCheckFunction(llvm::Module &M);
   llvm::Function *getSafetyCheckFunction(llvm::Module &M);
 


### PR DESCRIPTION
There is no need to cache memory safety functions on our end
since LLVM already does that for us.