### PR TITLE
Demangle C++/Rust names in the error traces

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -333,6 +333,7 @@ if [ ${INSTALL_RUST} -eq 1 ] ; then
   sudo ./install.sh --without=rust-docs
   cd ..
   rm -rf rust-nightly-x86_64-unknown-linux-gnu rust.tar.gz
+  cargo install rustfilt
   puts "Installed Rust"
 fi
 


### PR DESCRIPTION
This commit demangles function/variable names shown in the error traces of
failing C++/Rust programs. It invokes cxxfilt and rustfilt if they are in the
PATH. It also installs rustfilt when Rust is installed.