### PR TITLE
Flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
   - sudo apt-get install -y apt-transport-https
   - sudo apt-get update
   - sudo apt-get install -y clang-${LLVM_SHORT_VERSION} clang-format-${LLVM_SHORT_VERSION} llvm-${LLVM_SHORT_VERSION}-dev dotnet-sdk-3.1
-  - pip3 install -U pycodestyle
+  - pip3 install -U flake8
   - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_SHORT_VERSION} 20
   - sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_SHORT_VERSION} 20
   - sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-${LLVM_SHORT_VERSION} 20
@@ -73,5 +73,5 @@ before_script:
 
 script:
   - ./format/run-clang-format.py -e test/c/basic/transform-out.c -r lib/smack include/smack share/smack/include share/smack/lib test examples
-  - pycodestyle test/regtest.py share/smack/ -r --exclude share/smack/svcomp
+  - flake8 test/regtest.py share/smack/ --extend-exclude share/smack/svcomp/,share/smack/reach.py
   - INSTALL_RUST=1 ./bin/build.sh

--- a/share/smack/doctor.py
+++ b/share/smack/doctor.py
@@ -128,7 +128,7 @@ def main():
     check_command("llvm2bpl")
     check_command("smack")
 
-    if args.prefix != '':
+    if not args.prefix:
         check_headers(args.prefix)
 
     exit(count)

--- a/share/smack/doctor.py
+++ b/share/smack/doctor.py
@@ -8,7 +8,6 @@ from subprocess import Popen, PIPE
 import sys
 import re
 import argparse
-import platform
 
 
 def red(text):
@@ -129,7 +128,7 @@ def main():
     check_command("llvm2bpl")
     check_command("smack")
 
-    if args.prefix is not '':
+    if args.prefix != '':
         check_headers(args.prefix)
 
     exit(count)

--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import re
+import json
 from .utils import temporary_file, try_command
 
 
@@ -249,16 +251,17 @@ def json_compilation_database_frontend(input_file, args):
                 bit_codes = [re.sub('[.]o$', '.bc', f) for f in cc['objects']]
                 try_command(['llvm-link', '-o', args.bc_file] + bit_codes)
                 try_command(['llvm-link', '-o', args.linked_bc_file,
-                             args.bc_file] + build_libs(args))
+                             args.bc_file] + default_build_libs(args))
 
             else:
-                out_file = output_flags.findall(cc['command'])[0] + '.bc'
+                # out_file = output_flags.findall(cc['command'])[0] + '.bc'
                 command = cc['command']
                 command = output_flags.sub(r"-o \1.bc", command)
                 command = optimization_flags.sub("-O0", command)
                 command = command + " -emit-llvm"
                 try_command(command.split(), cc['directory'], console=True)
-
+    # import here to avoid a circular import
+    from .top import llvm_to_bpl
     llvm_to_bpl(args)
 
 

--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -254,7 +254,6 @@ def json_compilation_database_frontend(input_file, args):
                              args.bc_file] + default_build_libs(args))
 
             else:
-                # out_file = output_flags.findall(cc['command'])[0] + '.bc'
                 command = cc['command']
                 command = output_flags.sub(r"-o \1.bc", command)
                 command = optimization_flags.sub("-O0", command)

--- a/share/smack/replay.py
+++ b/share/smack/replay.py
@@ -1,7 +1,4 @@
-import os
 import re
-import subprocess
-import sys
 from .utils import temporary_file, try_command
 
 SPECIAL_NAMES = [

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -1,9 +1,6 @@
 import argparse
-import errno
-import io
 import json
 import os
-import platform
 import re
 import shutil
 import sys
@@ -90,7 +87,7 @@ def validate_input_files(files):
 def validate_output_file(file):
     dir_name = os.path.dirname(os.path.abspath(file))
     if not os.path.isdir(dir_name):
-        exit_with_error("directory %s doesn't exist" % dirname)
+        exit_with_error("directory %s doesn't exist" % dir_name)
     if not os.access(dir_name, os.W_OK):
         exit_with_error("file %s may not be writeable" % file)
     # try:

--- a/test/regtest.py
+++ b/test/regtest.py
@@ -4,12 +4,10 @@ from os import path
 from multiprocessing.pool import ThreadPool
 import multiprocessing
 import os
-import signal
 import logging
 import yaml
 import psutil
 import argparse
-from os import path
 import subprocess
 import re
 import glob


### PR DESCRIPTION
`flake8` (https://flake8.pycqa.org/en/latest/) is Python linter that incorporates `pycodestyle` which we previously used for checking conformality to PEP8. This PR fixes the issues reported by flake8 and also adds it the CI.