### PR TITLE
Decouple bit-precise-pointers from bit-precise

### DIFF
--- a/lib/smack/Prelude.cpp
+++ b/lib/smack/Prelude.cpp
@@ -328,7 +328,7 @@ struct IntOpGen::IntArithOp : public IntOp {
         (!SmackOptions::BitPrecisePointers && alsoUsedByPtr))
       funcs.push_back(getIntFunc(size));
     if (SmackOptions::BitPrecise ||
-        SmackOptions::BitPrecisePointers && alsoUsedByPtr)
+        (SmackOptions::BitPrecisePointers && alsoUsedByPtr))
       funcs.push_back(getBvFunc(size));
     return funcs;
   }

--- a/lib/smack/Prelude.cpp
+++ b/lib/smack/Prelude.cpp
@@ -327,7 +327,8 @@ struct IntOpGen::IntArithOp : public IntOp {
     if (!SmackOptions::BitPrecise ||
         (!SmackOptions::BitPrecisePointers && alsoUsedByPtr))
       funcs.push_back(getIntFunc(size));
-    if (SmackOptions::BitPrecise)
+    if (SmackOptions::BitPrecise ||
+        SmackOptions::BitPrecisePointers && alsoUsedByPtr)
       funcs.push_back(getBvFunc(size));
     return funcs;
   }
@@ -549,7 +550,7 @@ struct IntOpGen::IntPred : public IntOp {
       funcs.push_back(compFunc);
       funcs.push_back(predFunc);
     }
-    if (SmackOptions::BitPrecise) {
+    if (SmackOptions::BitPrecise || SmackOptions::BitPrecisePointers) {
       std::tie(compFunc, predFunc) = getBvFuncs(size);
       funcs.push_back(compFunc);
       funcs.push_back(predFunc);

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -439,9 +439,6 @@ def arguments():
         args.bpl_file = 'a.bpl' if args.no_verify else temporary_file(
             'a', '.bpl', args)
 
-    if args.bit_precise_pointers:
-        args.bit_precise = True
-
     # TODO are we (still) using this?
     # with open(args.input_file, 'r') as f:
     #   for line in f.readlines():

--- a/test/c/bits/pointers.c
+++ b/test/c/bits/pointers.c
@@ -1,0 +1,14 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @expect verified
+
+int main() {
+  int *a = (int *)malloc(sizeof(int));
+  int **p = (int **)malloc(sizeof(int *));
+  *a = 256;
+  *p = a;
+  assert(**p + 1 == 257);
+  free(a);
+  return 0;
+}

--- a/test/c/bits/pointers1.c
+++ b/test/c/bits/pointers1.c
@@ -1,0 +1,15 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @expect verified
+// @flag --bit-precise-pointers
+
+int main() {
+  int *a = (int *)malloc(sizeof(int));
+  int **p = (int **)malloc(sizeof(int *));
+  *a = 256;
+  *p = a;
+  assert(**p + 1 == 257);
+  free(a);
+  return 0;
+}

--- a/test/c/bits/pointers1_fail.c
+++ b/test/c/bits/pointers1_fail.c
@@ -1,0 +1,15 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @expect error
+// @flag --bit-precise-pointers
+
+int main() {
+  int *a = (int *)malloc(sizeof(int));
+  int **p = (int **)malloc(sizeof(int *));
+  *a = 256;
+  *p = a;
+  assert(**p + 1 != 257);
+  free(a);
+  return 0;
+}

--- a/test/c/bits/pointers_fail.c
+++ b/test/c/bits/pointers_fail.c
@@ -1,0 +1,14 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @expect error
+
+int main() {
+  int *a = (int *)malloc(sizeof(int));
+  int **p = (int **)malloc(sizeof(int *));
+  *a = 256;
+  *p = a;
+  assert(**p + 1 != 257);
+  free(a);
+  return 0;
+}

--- a/tools/llvm2bpl/llvm2bpl.cpp
+++ b/tools/llvm2bpl/llvm2bpl.cpp
@@ -117,10 +117,6 @@ int main(int argc, char **argv) {
   llvm::cl::ParseCommandLineOptions(
       argc, argv, "llvm2bpl - LLVM bitcode to Boogie transformation\n");
 
-  if (smack::SmackOptions::BitPrecisePointers) {
-    smack::SmackOptions::BitPrecise = true;
-  }
-
   llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
   llvm::PrettyStackTraceProgram PSTP(argc, argv);
   llvm::EnableDebugBuffering = true;


### PR DESCRIPTION
In the previous implementation, the former flag implies the latter flag, which
seems unnecessary.