### PR TITLE
Assert false on loop exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ add_library(smackTranslator STATIC
   include/smack/MemorySafetyChecker.h
   include/smack/IntegerOverflowChecker.h
   include/smack/NormalizeLoops.h
+  include/smack/AnnotateLoopEnds.h
   include/smack/SplitAggregateValue.h
   include/smack/Prelude.h
   include/smack/SmackWarnings.h
@@ -156,6 +157,7 @@ add_library(smackTranslator STATIC
   lib/smack/MemorySafetyChecker.cpp
   lib/smack/IntegerOverflowChecker.cpp
   lib/smack/NormalizeLoops.cpp
+  lib/smack/AnnotateLoopEnds.cpp
   lib/smack/SplitAggregateValue.cpp
   lib/smack/Prelude.cpp
   lib/smack/SmackWarnings.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ add_library(smackTranslator STATIC
   include/smack/MemorySafetyChecker.h
   include/smack/IntegerOverflowChecker.h
   include/smack/NormalizeLoops.h
-  include/smack/AnnotateLoopEnds.h
+  include/smack/AnnotateLoopExits.h
   include/smack/SplitAggregateValue.h
   include/smack/Prelude.h
   include/smack/SmackWarnings.h
@@ -157,7 +157,7 @@ add_library(smackTranslator STATIC
   lib/smack/MemorySafetyChecker.cpp
   lib/smack/IntegerOverflowChecker.cpp
   lib/smack/NormalizeLoops.cpp
-  lib/smack/AnnotateLoopEnds.cpp
+  lib/smack/AnnotateLoopExits.cpp
   lib/smack/SplitAggregateValue.cpp
   lib/smack/Prelude.cpp
   lib/smack/SmackWarnings.cpp

--- a/include/smack/AnnotateLoopEnds.h
+++ b/include/smack/AnnotateLoopEnds.h
@@ -1,0 +1,24 @@
+//
+// This file is distributed under the MIT License. See LICENSE for details.
+//
+#ifndef ANNOTATELOOPENDS_H
+#define ANNOTATELOOPENDS_H
+
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+#include <map>
+
+namespace smack {
+
+class AnnotateLoopEnds : public llvm::FunctionPass {
+public:
+  static char ID; // Pass identification, replacement for typeid
+  AnnotateLoopEnds() : llvm::FunctionPass(ID) {}
+  virtual llvm::StringRef getPassName() const override;
+  virtual bool runOnFunction(llvm::Function &F) override;
+  virtual void getAnalysisUsage(llvm::AnalysisUsage &) const override;
+};
+} // namespace smack
+
+#endif // ANNOTATELOOPENDS_H

--- a/include/smack/AnnotateLoopEnds.h
+++ b/include/smack/AnnotateLoopEnds.h
@@ -11,12 +11,12 @@
 
 namespace smack {
 
-class AnnotateLoopEnds : public llvm::FunctionPass {
+class AnnotateLoopEnds : public llvm::ModulePass {
 public:
   static char ID; // Pass identification, replacement for typeid
-  AnnotateLoopEnds() : llvm::FunctionPass(ID) {}
+  AnnotateLoopEnds() : llvm::ModulePass(ID) {}
   virtual llvm::StringRef getPassName() const override;
-  virtual bool runOnFunction(llvm::Function &F) override;
+  virtual bool runOnModule(llvm::Module &m) override;
   virtual void getAnalysisUsage(llvm::AnalysisUsage &) const override;
 };
 } // namespace smack

--- a/include/smack/AnnotateLoopExits.h
+++ b/include/smack/AnnotateLoopExits.h
@@ -1,8 +1,8 @@
 //
 // This file is distributed under the MIT License. See LICENSE for details.
 //
-#ifndef ANNOTATELOOPENDS_H
-#define ANNOTATELOOPENDS_H
+#ifndef ANNOTATELOOPEXITS_H
+#define ANNOTATELOOPEXITS_H
 
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
@@ -11,14 +11,14 @@
 
 namespace smack {
 
-class AnnotateLoopEnds : public llvm::ModulePass {
+class AnnotateLoopExits : public llvm::ModulePass {
 public:
   static char ID; // Pass identification, replacement for typeid
-  AnnotateLoopEnds() : llvm::ModulePass(ID) {}
+  AnnotateLoopExits() : llvm::ModulePass(ID) {}
   virtual llvm::StringRef getPassName() const override;
   virtual bool runOnModule(llvm::Module &m) override;
   virtual void getAnalysisUsage(llvm::AnalysisUsage &) const override;
 };
 } // namespace smack
 
-#endif // ANNOTATELOOPENDS_H
+#endif // ANNOTATELOOPEXITS_H

--- a/include/smack/SmackOptions.h
+++ b/include/smack/SmackOptions.h
@@ -30,6 +30,7 @@ public:
   static const llvm::cl::opt<bool> FloatEnabled;
   static const llvm::cl::opt<bool> MemorySafety;
   static const llvm::cl::opt<bool> IntegerOverflow;
+  static const llvm::cl::opt<bool> FailOnLoopExit;
   static const llvm::cl::opt<LLVMAssumeType> LLVMAssumes;
   static const llvm::cl::opt<bool> RustPanics;
   static const llvm::cl::opt<bool> AddTiming;

--- a/lib/smack/AnnotateLoopEnds.cpp
+++ b/lib/smack/AnnotateLoopEnds.cpp
@@ -1,0 +1,80 @@
+//
+// This file is distributed under the MIT License. See LICENSE for details.
+//
+
+//
+// This pass normalizes loop structures to allow easier generation of Boogie
+// code when a loop edge comes from a branch. Specifically, a forwarding block
+// is added between a branching block and the loop header.
+//
+
+#include "smack/AnnotateLoopEnds.h"
+#include "smack/Naming.h"
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Dominators.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/ValueSymbolTable.h"
+#include <map>
+#include <set>
+#include <vector>
+
+#include "llvm/Support/raw_ostream.h"
+
+namespace smack {
+
+using namespace llvm;
+
+// Register LoopInfo
+void AnnotateLoopEnds::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<LoopInfoWrapperPass>();
+}
+
+void processExitingBlock(BasicBlock *block) {
+  // print exit block found!!
+
+  errs() << "    Exit block found! \n";
+
+}
+
+void annotateLoopEnd(Loop *loop) {
+  //BasicBlock *headerBlock = loop->getHeader();
+
+  // I imagine that it is very uncommon for a loop to have
+  //   more than 5 exit points.
+  SmallVector<BasicBlock *, 5> exitingBlocks; 
+
+  loop->getExitingBlocks(exitingBlocks);
+  
+  for (BasicBlock *b : exitingBlocks) {
+    processExitingBlock(b);
+  } 
+
+  // Handle subloops
+  //for (Loop *subloop : loop->getSubLoops()) {
+  //  processLoop(subloop);
+  //}
+}
+
+bool AnnotateLoopEnds::runOnFunction(Function &F) {
+  if (F.isIntrinsic() || F.empty()) {
+    return false;
+  }
+  errs() << "Hello " << F.getName() << "\n";
+  LoopInfo &loopInfo = getAnalysis<LoopInfoWrapperPass>().getLoopInfo();
+  for (LoopInfo::iterator LI = loopInfo.begin(), LIEnd = loopInfo.end();
+       LI != LIEnd; ++LI) {
+    errs() << "  Loop Found in " << F.getName() << "\n";
+    annotateLoopEnd(*LI);
+  }
+
+  return true;
+}
+
+// Pass ID variable
+char AnnotateLoopEnds::ID = 0;
+
+StringRef AnnotateLoopEnds::getPassName() const { return "Annotate Loop Ends with assert(false)"; }
+} // namespace smack

--- a/lib/smack/AnnotateLoopExits.cpp
+++ b/lib/smack/AnnotateLoopExits.cpp
@@ -46,23 +46,22 @@ void processExitBlock(BasicBlock *block, Function *le) {
 
   SDEBUG(errs() << "Processing an Exit Block\n");
 
-  Instruction& front = block->front();
-  insertLoopEndAssertion(le,&front);
+  Instruction &front = block->front();
+  insertLoopEndAssertion(le, &front);
 }
 
 void annotateLoopEnd(Loop *loop, Function *le) {
-  //BasicBlock *headerBlock = loop->getHeader();
 
   // I imagine that it is very uncommon for a loop to have
   //   more than 5 exit points. This is a complete guess
   //   and we could probably have a better heuristic
-  SmallVector<BasicBlock *, 5> exitBlocks; 
+  SmallVector<BasicBlock *, 5> exitBlocks;
 
   loop->getExitBlocks(exitBlocks);
-  
+
   for (BasicBlock *b : exitBlocks) {
-    processExitBlock(b,le);
-  } 
+    processExitBlock(b, le);
+  }
 }
 
 bool AnnotateLoopExits::runOnModule(Module &m) {
@@ -90,5 +89,8 @@ bool AnnotateLoopExits::runOnModule(Module &m) {
 // Pass ID variable
 char AnnotateLoopExits::ID = 0;
 
-StringRef AnnotateLoopExits::getPassName() const { return "Annotate Loop Ends with assert(false)"; }
+StringRef AnnotateLoopExits::getPassName() const {
+  return "Annotate Loop Ends with assert(false)";
+}
+
 } // namespace smack

--- a/lib/smack/SmackOptions.cpp
+++ b/lib/smack/SmackOptions.cpp
@@ -66,6 +66,9 @@ const llvm::cl::opt<bool>
 const llvm::cl::opt<bool> SmackOptions::IntegerOverflow(
     "integer-overflow", llvm::cl::desc("Enable integer overflow checks"));
 
+const llvm::cl::opt<bool> SmackOptions::FailOnLoopExit("fail-on-loop-exit",
+    llvm::cl::desc("Add assert(false) to the end of each loop"));
+
 const llvm::cl::opt<LLVMAssumeType> SmackOptions::LLVMAssumes(
     "llvm-assumes",
     llvm::cl::desc(

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -52,6 +52,10 @@ void __SMACK_check_overflow(int flag) {
   __SMACK_code("assert {:overflow} @ == $0;", flag);
 }
 
+void __SMACK_loop_end(void) {
+  __SMACK_code("assert {:loopexit} false;");
+}
+
 char __VERIFIER_nondet_char(void) {
   char x = __SMACK_nondet_char();
   __VERIFIER_assume(x >= SCHAR_MIN && x <= SCHAR_MAX);

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -328,6 +328,12 @@ def arguments():
         default=False,
         help='enable support for string')
 
+    translate_group.add_argument(
+        '--fail-on-loop-exit',
+        action='store_true',
+        default=False,
+        help='Add assert false to the end of each loop (useful for deciding how much unroll to use)')
+
     verifier_group = parser.add_argument_group('verifier options')
 
     verifier_group.add_argument(
@@ -551,6 +557,8 @@ def llvm_to_bpl(args):
         cmd += ['-integer-overflow']
     if 'rust-panics' in args.check:
         cmd += ['-rust-panics']
+    if args.fail_on_loop_exit:
+        cmd += ['-fail-on-loop-exit']
     if args.llvm_assumes:
         cmd += ['-llvm-assumes=' + args.llvm_assumes]
     if args.float:

--- a/test/c/unroll/break2.c
+++ b/test/c/unroll/break2.c
@@ -1,0 +1,14 @@
+#include "smack.h"
+
+// @expect verified
+// @flag --unroll=4
+
+int main(void) {
+  int a = 1;
+  while (a < 10) {
+    if (a == 5) break;
+    a++;
+  }
+
+  return a;
+}

--- a/test/c/unroll/break2_fail.c
+++ b/test/c/unroll/break2_fail.c
@@ -1,0 +1,14 @@
+#include "smack.h"
+
+// @expect error
+// @flag --unroll=5
+
+int main(void) {
+  int a = 1;
+  while (a < 10) {
+    if (a == 5) break;
+    a++;
+  }
+
+  return a;
+}

--- a/test/c/unroll/config.yml
+++ b/test/c/unroll/config.yml
@@ -1,0 +1,2 @@
+skip: false
+flags: [--fail-on-loop-exit]

--- a/test/c/unroll/for_nested.c
+++ b/test/c/unroll/for_nested.c
@@ -1,0 +1,14 @@
+#include "smack.h"
+
+// @expect verified
+// @flag --unroll=5
+
+int main(void) {
+  int a;
+  int b;
+  int c = 0;
+  for (a = 0; a < 5; a++)
+    for (b = 0; b < 5; b++)
+      c++;
+  return c;
+}

--- a/test/c/unroll/for_nested_fail.c
+++ b/test/c/unroll/for_nested_fail.c
@@ -1,0 +1,14 @@
+#include "smack.h"
+
+// @expect error
+// @flag --unroll=6
+
+int main(void) {
+  int a;
+  int b;
+  int c = 0;
+  for (a = 0; a < 5; a++)
+    for (b = 0; b < 5; b++)
+      c++;
+  return c;
+}

--- a/test/c/unroll/for_unroll.c
+++ b/test/c/unroll/for_unroll.c
@@ -1,0 +1,12 @@
+#include "smack.h"
+
+// @expect verified
+// @flag --unroll=10
+
+int main(void) {
+  int a;
+  int b = 0;
+  for (a = 0; a < 10; a++)
+    b++;
+  return b;
+}

--- a/test/c/unroll/for_unroll_fail.c
+++ b/test/c/unroll/for_unroll_fail.c
@@ -1,0 +1,12 @@
+#include "smack.h"
+
+// @expect error
+// @flag --unroll=11
+
+int main(void) {
+  int a;
+  int b = 0;
+  for (a = 0; a < 10; a++)
+    b++;
+  return b;
+}

--- a/test/c/unroll/goto_exit.c
+++ b/test/c/unroll/goto_exit.c
@@ -1,0 +1,28 @@
+#include "smack.h"
+
+// @expect verified
+// @flag --unroll=6
+
+int func(int a) {
+  int ans = 0;
+
+  if (a < 5) {
+    goto exit;
+  }
+
+  for (int i = 0; i < a; i++)
+    ans++;
+
+exit:
+  ans++;
+  return ans;
+}
+
+int main(void) {
+  int i = func(2);
+  int j = func(6);
+
+  return i + j;
+}
+
+

--- a/test/c/unroll/goto_exit_fail.c
+++ b/test/c/unroll/goto_exit_fail.c
@@ -1,0 +1,28 @@
+#include "smack.h"
+
+// @expect error
+// @flag --unroll=7
+
+int func(int a) {
+  int ans = 0;
+
+  if (a < 5) {
+    goto exit;
+  }
+
+  for (int i = 0; i < a; i++)
+    ans++;
+
+exit:
+  ans++;
+  return ans;
+}
+
+int main(void) {
+  int i = func(2);
+  int j = func(6);
+
+  return i + j;
+}
+
+

--- a/test/c/unroll/two_exits.c
+++ b/test/c/unroll/two_exits.c
@@ -1,0 +1,20 @@
+#include "smack.h"
+
+// @expect verified
+// @flag --unroll=5
+
+int func(int p) {
+  int a = 0;
+  while (a < 10) {
+    if (a == p) break;
+    a++;
+  }
+  return a;
+}
+
+int main(void) {
+  int i = func(5);
+  int j = func(15);
+
+  return i + j;
+}

--- a/test/c/unroll/two_exits_fail.c
+++ b/test/c/unroll/two_exits_fail.c
@@ -1,0 +1,20 @@
+#include "smack.h"
+
+// @expect error
+// @flag --unroll=6
+
+int func(int p) {
+  int a = 0;
+  while (a < 10) {
+    if (a == p) break;
+    a++;
+  }
+  return a;
+}
+
+int main(void) {
+  int i = func(5);
+  int j = func(15);
+
+  return i + j;
+}

--- a/test/c/unroll/two_loops.c
+++ b/test/c/unroll/two_loops.c
@@ -1,0 +1,16 @@
+#include "smack.h"
+
+// @expect verified
+// @flag --unroll=5
+
+int main(void) {
+  int c = 0;
+
+  for (int a = 0; a < 5; a++)
+    c++;
+
+  for (int a = 0; a < 10; a++)
+    c++;
+
+  return c;
+}

--- a/test/c/unroll/two_loops2.c
+++ b/test/c/unroll/two_loops2.c
@@ -1,0 +1,16 @@
+#include "smack.h"
+
+// @expect verified
+// @flag --unroll=10
+
+int main(void) {
+  int c = 0;
+
+  for (int a = 0; a < 10; a++)
+    c++;
+
+  for (int a = 0; a < 5; a++)
+    c++;
+
+  return c;
+}

--- a/test/c/unroll/two_loops2_fail.c
+++ b/test/c/unroll/two_loops2_fail.c
@@ -1,0 +1,16 @@
+#include "smack.h"
+
+// @expect error
+// @flag --unroll=11
+
+int main(void) {
+  int c = 0;
+
+  for (int a = 0; a < 10; a++)
+    c++;
+
+  for (int a = 0; a < 5; a++)
+    c++;
+
+  return c;
+}

--- a/test/c/unroll/two_loops_fail.c
+++ b/test/c/unroll/two_loops_fail.c
@@ -1,0 +1,16 @@
+#include "smack.h"
+
+// @expect error
+// @flag --unroll=6
+
+int main(void) {
+  int c = 0;
+
+  for (int a = 0; a < 5; a++)
+    c++;
+
+  for (int a = 0; a < 10; a++)
+    c++;
+
+  return c;
+}

--- a/test/c/unroll/while_nested.c
+++ b/test/c/unroll/while_nested.c
@@ -1,0 +1,19 @@
+#include "smack.h"
+
+// @expect verified
+// @flag --unroll=8
+
+int main(void) {
+  int a = 1;
+  int c = 0;
+  while (a < 9) {
+    int b = 1;
+    while (b < a) {
+      if (a % b == 0) // b divides a
+        c++;
+      b++;
+    }
+    a++;
+  }
+  return c;
+}

--- a/test/c/unroll/while_nested_fail.c
+++ b/test/c/unroll/while_nested_fail.c
@@ -1,0 +1,19 @@
+#include "smack.h"
+
+// @expect error
+// @flag --unroll=9
+
+int main(void) {
+  int a = 1;
+  int c = 0;
+  while (a < 9) {
+    int b = 1;
+    while (b < a) {
+      if (a % b == 0) // b divides a
+        c++;
+      b++;
+    }
+    a++;
+  }
+  return c;
+}

--- a/tools/llvm2bpl/llvm2bpl.cpp
+++ b/tools/llvm2bpl/llvm2bpl.cpp
@@ -36,7 +36,7 @@
 #include "smack/IntegerOverflowChecker.h"
 #include "smack/MemorySafetyChecker.h"
 #include "smack/NormalizeLoops.h"
-#include "smack/AnnotateLoopEnds.h"
+#include "smack/AnnotateLoopExits.h"
 #include "smack/RemoveDeadDefs.h"
 #include "smack/SimplifyLibCalls.h"
 #include "smack/SmackModuleGenerator.h"
@@ -169,7 +169,7 @@ int main(int argc, char **argv) {
 
   // pass_manager.add(new llvm::StructRet());
   pass_manager.add(new smack::NormalizeLoops());
-  pass_manager.add(new smack::AnnotateLoopEnds());
+  pass_manager.add(new smack::AnnotateLoopExits());
   pass_manager.add(new llvm::SimplifyEV());
   pass_manager.add(new llvm::SimplifyIV());
   pass_manager.add(new smack::ExtractContracts());

--- a/tools/llvm2bpl/llvm2bpl.cpp
+++ b/tools/llvm2bpl/llvm2bpl.cpp
@@ -29,6 +29,7 @@
 #include "utils/SimplifyExtractValue.h"
 #include "utils/SimplifyInsertValue.h"
 #include "smack/AddTiming.h"
+#include "smack/AnnotateLoopExits.h"
 #include "smack/BplFilePrinter.h"
 #include "smack/CodifyStaticInits.h"
 #include "smack/ExtractContracts.h"
@@ -36,7 +37,6 @@
 #include "smack/IntegerOverflowChecker.h"
 #include "smack/MemorySafetyChecker.h"
 #include "smack/NormalizeLoops.h"
-#include "smack/AnnotateLoopExits.h"
 #include "smack/RemoveDeadDefs.h"
 #include "smack/SimplifyLibCalls.h"
 #include "smack/SmackModuleGenerator.h"
@@ -169,7 +169,9 @@ int main(int argc, char **argv) {
 
   // pass_manager.add(new llvm::StructRet());
   pass_manager.add(new smack::NormalizeLoops());
-  pass_manager.add(new smack::AnnotateLoopExits());
+  if (smack::SmackOptions::FailOnLoopExit) {
+    pass_manager.add(new smack::AnnotateLoopExits());
+  }
   pass_manager.add(new llvm::SimplifyEV());
   pass_manager.add(new llvm::SimplifyIV());
   pass_manager.add(new smack::ExtractContracts());

--- a/tools/llvm2bpl/llvm2bpl.cpp
+++ b/tools/llvm2bpl/llvm2bpl.cpp
@@ -36,6 +36,7 @@
 #include "smack/IntegerOverflowChecker.h"
 #include "smack/MemorySafetyChecker.h"
 #include "smack/NormalizeLoops.h"
+#include "smack/AnnotateLoopEnds.h"
 #include "smack/RemoveDeadDefs.h"
 #include "smack/SimplifyLibCalls.h"
 #include "smack/SmackModuleGenerator.h"
@@ -168,6 +169,7 @@ int main(int argc, char **argv) {
 
   // pass_manager.add(new llvm::StructRet());
   pass_manager.add(new smack::NormalizeLoops());
+  pass_manager.add(new smack::AnnotateLoopEnds());
   pass_manager.add(new llvm::SimplifyEV());
   pass_manager.add(new llvm::SimplifyIV());
   pass_manager.add(new smack::ExtractContracts());


### PR DESCRIPTION
This partly addresses #434 

This PR adds a pass that finds every loop exit and adds an `assert false` using `__SMACK_code` at each exit. The idea is that if a user is not sure if their loop is unrolling enough, then they can use the flag `--fail-on-loop-exit`, and if the program does not fail, that means the unroll bound is not enough.

Some technical notes:
* this pass requires the LoopSimplifyPass from LLVM to run before it does. Among other things, LoopSimplifyPass guarentees that no BasicBlock which is an "exit block" of the loop (that is, it has a predecessor block inside the loop) has a predecessor that is not inside the loop. If such a block existed, this would make a subtle bug where the assertion could fail even though the loop hadn't been unrolled enough. LoopSimplifyPass should keep this from happening. I haven't been able to come up with C code that compile (at level -O0) into this edge case, so I can't demonstrate the necessity of this pass yet.
* as this pass adds an `assert false` to every single loop exit it finds, if SMACK fails, what it really tells us is that ONE exit point of the FIRST loop is reachable. There could a few possible enhancements:
--> Right now, nested loops inside an outer loop are not considered. If SMACK runs and does not fail in the situation of a nested loop, there's no way to tell which loop wasn't unrolled enough. Modifying the pass so that the user can detect precisely which nested loop is the issue should be easy, however @shaobo-he and I aren't sure if it would be that useful, so it has not been implemented.
--> There could be multiple exit points to the loop, i.e. there could be a break statement (or goto, I guess). Because this pass can only tell if ONE of the exit points of the loop can be reached, there could be a loop which isn't unrolled enough for all possible inputs, but only for some inputs (see `test/c/unroll/two_exits.c`). Enhancing this would require some type of annotating the break statements or something, and I imagine it could be hard.
--> There could be multiple outer loops in the program (`two_loops.c` and `two_loops2.c`). In this case, because this pass adds assertions to all loops, as soon as it finds the exit to the first loop, it will terminate. If there is a second loop which requires greater unroll to exit than the first, SMACK won't be able to tell. There are a couple of ways one could think about trying to fix this. 

I'm interested in thoughts from @shaobo-he @keram88 @zvonimir and @michael-emmi on how we might enhance this functionality. In the meantime maybe we can merge this so we have something. This is also the first LLVM pass I've written, so I'm eager for feedback on coding style, etc.