### PR TITLE
Fixed a non-semantically-preserving change introduced by autopep8

### DIFF
--- a/test/regtest.py
+++ b/test/regtest.py
@@ -315,10 +315,10 @@ def main():
             if meta['memory-limit'] > mem_total:
                 continue
 
-            if meta['skip'] == True:
+            if meta['skip'] is True:
                 continue
 
-            if meta['skip'] != False and not args.all_examples:
+            if meta['skip'] is not False and not args.all_examples:
                 continue
 
             # build up the subprocess command

--- a/test/regtest.py
+++ b/test/regtest.py
@@ -315,10 +315,10 @@ def main():
             if meta['memory-limit'] > mem_total:
                 continue
 
-            if meta['skip']:
+            if meta['skip'] == True:
                 continue
 
-            if meta['skip'] and not args.all_examples:
+            if meta['skip'] != False and not args.all_examples:
                 continue
 
             # build up the subprocess command


### PR DESCRIPTION
Specifically, commit 086b4da5680e1ce03048395dd0b94a17a17aeedc changed lines
```
if meta['skip'] == True:
  continue

if meta['skip'] != False and not args.all_examples:
  continue
```
into
```
if meta['skip']:
    continue
if meta['skip'] and not args.all_examples:
    continue
```

Apparently they are not semantically-equivalent and caused our CI to skip tests
unexpectedly.