### PR TITLE
Add integer encoding and pointer encoding options

### DIFF
--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -95,7 +95,7 @@ def default_clang_compile_command(args, lib=False):
         cmd += ['-DFLOAT_ENABLED']
     if args.pthread:
         cmd += ['-DSMACK_MAX_THREADS=' + str(args.max_threads)]
-    if args.bit_precise:
+    if args.integer_encoding == 'bit-vector':
         cmd += ['-DBIT_PRECISE']
     if sys.stdout.isatty():
         cmd += ['-fcolor-diagnostics']

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -262,10 +262,14 @@ def arguments():
         help='bound on the number of threads [default: %(default)s]')
 
     translate_group.add_argument(
-        '--bit-precise',
-        action="store_true",
-        default=False,
-        help='model non-pointer values as bit vectors')
+        '--integer-encoding',
+        choices=['bit-vector', 'unbounded-integer', 'wrapped-integer'],
+        default='unbounded-integer',
+        help='''machine integer encoding
+                (bit-vector=use SMT bit-vector theory,
+                unbounded-integer=use SMT integer theory,
+                wrapped-integer=use SMT integer theory but model wrap-around
+                behavior) [default: %(default)s]''')
 
     translate_group.add_argument(
         '--timing-annotations',
@@ -274,10 +278,13 @@ def arguments():
         help='enable timing annotations')
 
     translate_group.add_argument(
-        '--bit-precise-pointers',
-        action="store_true",
-        default=False,
-        help='model pointers and non-pointer values as bit vectors')
+        '--pointer-encoding',
+        choices=['bit-vector', 'unbounded-integer'],
+        default='unbounded-integer',
+        help='''pointer encoding
+                (bit-vector=use SMT bit-vector theory,
+                ubounded-integer=use SMT integer theory)
+                [default: %(default)s]''')
 
     translate_group.add_argument(
         '--no-byte-access-inference',
@@ -303,13 +310,6 @@ def arguments():
                 [choices: %(choices)s; default: %(default)s]
                 (note that memory-safety is the union of valid-deref,
                 valid-free, memleak)''')
-
-    translate_group.add_argument(
-        '--wrapped-integer-encoding',
-        action='store_true',
-        default=False,
-        help='''enable wrapped integer arithmetic and signedness-aware
-                comparison''')
 
     translate_group.add_argument(
         '--llvm-assumes',
@@ -538,11 +538,13 @@ def llvm_to_bpl(args):
         cmd += ['-mem-mod-impls']
     if args.static_unroll:
         cmd += ['-static-unroll']
-    if args.bit_precise:
+    if args.integer_encoding == 'bit-vector':
         cmd += ['-bit-precise']
+    if args.integer_encoding == 'wrapped-integer':
+        cmd += ['-wrapped-integer-encoding']
     if args.timing_annotations:
         cmd += ['-timing-annotations']
-    if args.bit_precise_pointers:
+    if args.pointer_encoding == 'bit-vector':
         cmd += ['-bit-precise-pointers']
     if args.no_byte_access_inference:
         cmd += ['-no-byte-access-inference']
@@ -555,8 +557,6 @@ def llvm_to_bpl(args):
         cmd += ['-integer-overflow']
     if 'rust-panics' in args.check:
         cmd += ['-rust-panics']
-    if args.wrapped_integer_encoding:
-        cmd += ['-wrapped-integer-encoding']
     if args.llvm_assumes:
         cmd += ['-llvm-assumes=' + args.llvm_assumes]
     if args.float:

--- a/test/c/basic/sext.c
+++ b/test/c/basic/sext.c
@@ -2,7 +2,7 @@
 #include <limits.h>
 
 // @expect verified
-// @flag --wrapped-integer-encoding
+// @flag --integer-encoding=wrapped-integer
 
 int main(void) {
   int xs = INT_MAX;

--- a/test/c/basic/sext_fail.c
+++ b/test/c/basic/sext_fail.c
@@ -2,7 +2,7 @@
 #include <limits.h>
 
 // @expect error
-// @flag --wrapped-integer-encoding
+// @flag --integer-encoding=wrapped-integer
 
 int main(void) {
   int xs = INT_MAX;

--- a/test/c/basic/trunc.c
+++ b/test/c/basic/trunc.c
@@ -2,7 +2,7 @@
 #include <limits.h>
 
 // @expect verified
-// @flag --wrapped-integer-encoding
+// @flag --integer-encoding=wrapped-integer
 
 int main(void) {
   unsigned long xl = ULONG_MAX;

--- a/test/c/basic/trunc_fail.c
+++ b/test/c/basic/trunc_fail.c
@@ -2,7 +2,7 @@
 #include <limits.h>
 
 // @expect error
-// @flag --wrapped-integer-encoding
+// @flag --integer-encoding=wrapped-integer
 
 int main(void) {
   unsigned long xl = ULONG_MAX;

--- a/test/c/basic/unsigned_max.c
+++ b/test/c/basic/unsigned_max.c
@@ -2,7 +2,7 @@
 #include <limits.h>
 
 // @expect verified
-// @flag --wrapped-integer-encoding
+// @flag --integer-encoding=wrapped-integer
 
 int main(void) {
   unsigned x = __VERIFIER_nondet_unsigned();

--- a/test/c/basic/unsigned_max_fail.c
+++ b/test/c/basic/unsigned_max_fail.c
@@ -2,7 +2,7 @@
 #include <limits.h>
 
 // @expect error
-// @flag --wrapped-integer-encoding
+// @flag --integer-encoding=wrapped-integer
 
 int main(void) {
   unsigned x = __VERIFIER_nondet_unsigned();

--- a/test/c/basic/unsigned_underflow.c
+++ b/test/c/basic/unsigned_underflow.c
@@ -1,7 +1,7 @@
 #include <smack.h>
 
 // @expect verified
-// @flag --wrapped-integer-encoding
+// @flag --integer-encoding=wrapped-integer
 
 int main() {
   unsigned x = 2;

--- a/test/c/basic/unsigned_underflow_fail.c
+++ b/test/c/basic/unsigned_underflow_fail.c
@@ -1,7 +1,7 @@
 #include <smack.h>
 
 // @expect error
-// @flag --wrapped-integer-encoding
+// @flag --integer-encoding=wrapped-integer
 
 int main() {
   unsigned x = 2;

--- a/test/c/basic/zext.c
+++ b/test/c/basic/zext.c
@@ -2,7 +2,7 @@
 #include <limits.h>
 
 // @expect verified
-// @flag --wrapped-integer-encoding
+// @flag --integer-encoding=wrapped-integer
 
 int main(void) {
   unsigned xs = UINT_MAX;

--- a/test/c/basic/zext_fail.c
+++ b/test/c/basic/zext_fail.c
@@ -2,7 +2,7 @@
 #include <limits.h>
 
 // @expect error
-// @flag --wrapped-integer-encoding
+// @flag --integer-encoding=wrapped-integer
 
 int main(void) {
   unsigned xs = UINT_MAX;

--- a/test/c/bits/config.yml
+++ b/test/c/bits/config.yml
@@ -1,2 +1,2 @@
 skip: ok
-flags: [--bit-precise]
+flags: [--integer-encoding=bit-vector]

--- a/test/c/bits/malloc_non_alias.c
+++ b/test/c/bits/malloc_non_alias.c
@@ -1,7 +1,7 @@
 #include "smack.h"
 #include <stdlib.h>
 
-// @flag --bit-precise-pointers
+// @flag --pointer-encoding=bit-vector
 // @expect verified
 
 int main(void) {

--- a/test/c/bits/pack_struct.c
+++ b/test/c/bits/pack_struct.c
@@ -10,7 +10,7 @@ struct S {
 
 // Clang packs each argument as a 64-bit integer,
 // which introduces false alarms without
-// the `--bit-precise` flag
+// the `--integer-encoding=bit-vector` flag
 bool eq(struct S p1, struct S p2) { return p1.y == p2.y; }
 
 int main(void) {

--- a/test/c/bits/pack_struct_fail.c
+++ b/test/c/bits/pack_struct_fail.c
@@ -10,7 +10,7 @@ struct S {
 
 // Clang packs each argument as a 64-bit integer,
 // which introduces false alarms without
-// the `--bit-precise` flag
+// the `--integer-encoding=bit-vector` flag
 bool eq(struct S p1, struct S p2) { return p1.y == p2.y; }
 
 int main(void) {

--- a/test/c/bits/pointers1.c
+++ b/test/c/bits/pointers1.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 
 // @expect verified
-// @flag --bit-precise-pointers
+// @flag --pointer-encoding=bit-vector
 
 int main() {
   int *a = (int *)malloc(sizeof(int));

--- a/test/c/bits/pointers1_fail.c
+++ b/test/c/bits/pointers1_fail.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 
 // @expect error
-// @flag --bit-precise-pointers
+// @flag --pointer-encoding=bit-vector
 
 int main() {
   int *a = (int *)malloc(sizeof(int));

--- a/test/c/float/bitcast.c
+++ b/test/c/float/bitcast.c
@@ -1,6 +1,6 @@
 #include "smack.h"
 
-// @flag --bit-precise --clang-options="-fno-strict-aliasing"
+// @flag --integer-encoding=bit-vector --clang-options="-fno-strict-aliasing"
 // @expect verified
 
 int main(void) {

--- a/test/c/float/bitcast_fail.c
+++ b/test/c/float/bitcast_fail.c
@@ -1,6 +1,6 @@
 #include "smack.h"
 
-// @flag --bit-precise --clang-options="-fno-strict-aliasing"
+// @flag --integer-encoding=bit-vector --clang-options="-fno-strict-aliasing"
 // @expect error
 
 int main(void) {

--- a/test/c/float/double_to_int.c
+++ b/test/c/float/double_to_int.c
@@ -1,6 +1,6 @@
 #include "smack.h"
 
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 // @expect verified
 
 int main(void) {

--- a/test/c/float/double_to_int_fail.c
+++ b/test/c/float/double_to_int_fail.c
@@ -1,6 +1,6 @@
 #include "smack.h"
 
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 // @expect error
 
 int main(void) {

--- a/test/c/float/float_int_union.c
+++ b/test/c/float/float_int_union.c
@@ -1,6 +1,6 @@
 #include "smack.h"
 
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 // @expect verified
 
 union mix {

--- a/test/c/float/float_int_union_fail.c
+++ b/test/c/float/float_int_union_fail.c
@@ -1,6 +1,6 @@
 #include "smack.h"
 
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 // @expect error
 
 union mix {

--- a/test/c/float/floor.c
+++ b/test/c/float/floor.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   assert(floor(2.7) == 2.0);

--- a/test/c/float/floor_fail.c
+++ b/test/c/float/floor_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   assert(floor(2.7) == 2.0);

--- a/test/c/float/half_intrinsics.c
+++ b/test/c/float/half_intrinsics.c
@@ -1,7 +1,7 @@
 #include "math.h"
 #include "smack.h"
 
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 // @expect verified
 
 int main(void) {

--- a/test/c/float/half_intrinsics_fail.c
+++ b/test/c/float/half_intrinsics_fail.c
@@ -1,7 +1,7 @@
 #include "math.h"
 #include "smack.h"
 
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 // @expect error
 
 int main(void) {

--- a/test/c/mathc/ceil.c
+++ b/test/c/mathc/ceil.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/ceil_fail.c
+++ b/test/c/mathc/ceil_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/ceilf.c
+++ b/test/c/mathc/ceilf.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/ceilf_fail.c
+++ b/test/c/mathc/ceilf_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/copysign.c
+++ b/test/c/mathc/copysign.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/copysign_fail.c
+++ b/test/c/mathc/copysign_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/copysignf.c
+++ b/test/c/mathc/copysignf.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/copysignf_fail.c
+++ b/test/c/mathc/copysignf_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/fabs.c
+++ b/test/c/mathc/fabs.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/fabs_fail.c
+++ b/test/c/mathc/fabs_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/fabsf.c
+++ b/test/c/mathc/fabsf.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/fabsf_fail.c
+++ b/test/c/mathc/fabsf_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/floor.c
+++ b/test/c/mathc/floor.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/floor_fail.c
+++ b/test/c/mathc/floor_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/floorf.c
+++ b/test/c/mathc/floorf.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/floorf_fail.c
+++ b/test/c/mathc/floorf_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/fmod.c
+++ b/test/c/mathc/fmod.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/fmod_fail.c
+++ b/test/c/mathc/fmod_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/fmodf.c
+++ b/test/c/mathc/fmodf.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/fmodf_fail.c
+++ b/test/c/mathc/fmodf_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/issue_244.c
+++ b/test/c/mathc/issue_244.c
@@ -2,6 +2,6 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) { assert(!__signbit(remainder(0.0, 1.0))); }

--- a/test/c/mathc/issue_244_fail.c
+++ b/test/c/mathc/issue_244_fail.c
@@ -2,6 +2,6 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) { assert(__signbit(remainder(0.0, 1.0))); }

--- a/test/c/mathc/lrint.c
+++ b/test/c/mathc/lrint.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/lrint_fail.c
+++ b/test/c/mathc/lrint_fail.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/lrintf.c
+++ b/test/c/mathc/lrintf.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/lrintf_fail.c
+++ b/test/c/mathc/lrintf_fail.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/lround.c
+++ b/test/c/mathc/lround.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/lround_fail.c
+++ b/test/c/mathc/lround_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/lroundf.c
+++ b/test/c/mathc/lroundf.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/lroundf_fail.c
+++ b/test/c/mathc/lroundf_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/modf.c
+++ b/test/c/mathc/modf.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/modf_fail.c
+++ b/test/c/mathc/modf_fail.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/modff.c
+++ b/test/c/mathc/modff.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/modff_fail.c
+++ b/test/c/mathc/modff_fail.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/nearbyint.c
+++ b/test/c/mathc/nearbyint.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/nearbyint_fail.c
+++ b/test/c/mathc/nearbyint_fail.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/nearbyintf.c
+++ b/test/c/mathc/nearbyintf.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/nearbyintf_fail.c
+++ b/test/c/mathc/nearbyintf_fail.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/rint.c
+++ b/test/c/mathc/rint.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/rint_fail.c
+++ b/test/c/mathc/rint_fail.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/rintf.c
+++ b/test/c/mathc/rintf.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/rintf_fail.c
+++ b/test/c/mathc/rintf_fail.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/round.c
+++ b/test/c/mathc/round.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/round_fail.c
+++ b/test/c/mathc/round_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/roundf.c
+++ b/test/c/mathc/roundf.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/roundf_fail.c
+++ b/test/c/mathc/roundf_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/sqrt.c
+++ b/test/c/mathc/sqrt.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/sqrt_fail.c
+++ b/test/c/mathc/sqrt_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/sqrtf.c
+++ b/test/c/mathc/sqrtf.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/sqrtf_fail.c
+++ b/test/c/mathc/sqrtf_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/trunc.c
+++ b/test/c/mathc/trunc.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/trunc_fail.c
+++ b/test/c/mathc/trunc_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   double NaN = 0.0 / 0.0;

--- a/test/c/mathc/truncf.c
+++ b/test/c/mathc/truncf.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect verified
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/mathc/truncf_fail.c
+++ b/test/c/mathc/truncf_fail.c
@@ -2,7 +2,7 @@
 #include <math.h>
 
 // @expect error
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   float NaN = 0.0f / 0.0f;

--- a/test/c/special/assume.c
+++ b/test/c/special/assume.c
@@ -5,8 +5,8 @@
 
 int main(void) {
   unsigned int y = 2 * (unsigned int)__VERIFIER_nondet_unsigned_short();
-  // This assumption is used for verification, even though bit-precise
-  // is not enabled, the assertion will pass.
+  // This assumption is used for verification, even though
+  // integer-encoding=bit-vector is not enabled, the assertion will pass.
   __builtin_assume((y & 1) == 0);
   assert((y & 1) == 0);
 }

--- a/test/c/special/assume_check.c
+++ b/test/c/special/assume_check.c
@@ -2,11 +2,12 @@
 
 // @expect verified
 // @flag --llvm-assumes=check
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   unsigned int y = 2 * (unsigned int)__VERIFIER_nondet_unsigned_short();
-  // This assumption is checked under bit-precise and is verified.
+  // This assumption is checked under integer-encoding=bit-vector and is
+  // verified.
   __builtin_assume((y & 1) == 0);
   assert((y & 1) == 0);
 }

--- a/test/c/special/assume_check2.c
+++ b/test/c/special/assume_check2.c
@@ -2,12 +2,13 @@
 
 // @expect verified
 // @flag --llvm-assumes=check
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   unsigned int y = (2 * (unsigned int)__VERIFIER_nondet_unsigned_short()) + 1;
-  // This assumption is checked at verification time, and since bit-precise
-  // is enabled, and y is clearly odd, the check will pass.
+  // This assumption is checked at verification time, and since
+  // integer-encoding=bit-vector is enabled, and y is clearly odd, the check
+  // will pass.
   __builtin_assume((y & 1) == 1);
   assert((y & 1) == 1);
 }

--- a/test/c/special/assume_check_fail.c
+++ b/test/c/special/assume_check_fail.c
@@ -2,12 +2,13 @@
 
 // @expect error
 // @flag --llvm-assumes=check
-// @flag --bit-precise
+// @flag --integer-encoding=bit-vector
 
 int main(void) {
   unsigned int y = (2 * (unsigned int)__VERIFIER_nondet_unsigned_short()) + 1;
-  // This assumption is checked at verification time, and since bit-precise
-  // is enabled, and y is clearly odd, the assumption should be shown false.
+  // This assumption is checked at verification time, and since
+  // integer-encoding=bit-vector is enabled, and y is clearly odd, the
+  // assumption should be shown false.
   __builtin_assume((y & 1) == 0);
   assert((y & 1) == 0);
 }

--- a/test/c/special/assume_fail.c
+++ b/test/c/special/assume_fail.c
@@ -5,8 +5,8 @@
 
 int main(void) {
   unsigned int y = 2 * (unsigned int)__VERIFIER_nondet_unsigned_short();
-  // This assumption is not used, and since bit-precise is not enabled,
-  // verification will fail.
+  // This assumption is not used, and since integer-encoding=bit-vector is
+  // not enabled, verification will fail.
   __builtin_assume((y & 1) == 0);
   assert((y & 1) == 0);
 }


### PR DESCRIPTION
This PR replaces old `--bit-precise`, `--bit-precise-pointers`, and `--wrapped-integer-encoding` flags with new `--integer-encoding` and `--pointer-encoding` flags.