### PR TITLE
Turn off clang-format for a comment in test/c/basic/transform-out.c

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,6 @@ before_script:
   - llvm-config --version
 
 script:
-  - ./format/run-clang-format.py -e test/c/basic/transform-out.c -r lib/smack include/smack share/smack/include share/smack/lib test examples
+  - ./format/run-clang-format.py -r lib/smack include/smack share/smack/include share/smack/lib test examples
   - flake8 test/regtest.py share/smack/ --extend-exclude share/smack/svcomp/,share/smack/reach.py
   - INSTALL_RUST=1 ./bin/build.sh

--- a/test/c/basic/transform-out.c
+++ b/test/c/basic/transform-out.c
@@ -3,7 +3,9 @@
 #include <stdlib.h>
 
 // @expect verified
+// clang-format off
 // @flag --transform-out "sed -e 's/[[:digit:]]* verified, [[:digit:]]* error/1 verified, 0 errors/' -e 's/can fail/no bugs/'"
+// clang-format on
 
 int main(void) {
   assert(0);


### PR DESCRIPTION
This commit allows clang-format to still check that file.