### PR TITLE
Update handling of Rust entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ add_library(smackTranslator STATIC
   include/smack/MemorySafetyChecker.h
   include/smack/IntegerOverflowChecker.h
   include/smack/NormalizeLoops.h
+  include/smack/RustFixes.h
   include/smack/SplitAggregateValue.h
   include/smack/Prelude.h
   include/smack/SmackWarnings.h
@@ -156,6 +157,7 @@ add_library(smackTranslator STATIC
   lib/smack/MemorySafetyChecker.cpp
   lib/smack/IntegerOverflowChecker.cpp
   lib/smack/NormalizeLoops.cpp
+  lib/smack/RustFixes.cpp
   lib/smack/SplitAggregateValue.cpp
   lib/smack/Prelude.cpp
   lib/smack/SmackWarnings.cpp

--- a/include/smack/Naming.h
+++ b/include/smack/Naming.h
@@ -93,6 +93,7 @@ public:
   static const std::string MEMORY_LEAK_FUNCTION;
 
   static const std::string RUST_ENTRY;
+  static const std::string RUST_LANG_START_INTERNAL;
   static const std::vector<std::string> RUST_PANICS;
   static const std::string RUST_PANIC_ANNOTATION;
 

--- a/include/smack/RustFixes.h
+++ b/include/smack/RustFixes.h
@@ -1,0 +1,23 @@
+//
+// This file is distributed under the MIT License. See LICENSE for details.
+//
+
+#ifndef RUSTFIXES_H
+#define RUSTFIXES_H
+
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+
+namespace smack {
+
+class RustFixes : public llvm::ModulePass {
+public:
+  static char ID; // Pass identification, replacement for typeid
+  RustFixes() : llvm::ModulePass(ID) {}
+  virtual llvm::StringRef getPassName() const;
+  virtual bool runOnModule(llvm::Module &m);
+};
+} // namespace smack
+
+#endif // RUSTFIXES_H

--- a/lib/smack/Naming.cpp
+++ b/lib/smack/Naming.cpp
@@ -62,6 +62,8 @@ const std::string Naming::REC_MEM_OP = "boogie_si_record_mop";
 const std::string Naming::MEM_OP_VAL = "$MOP";
 
 const std::string Naming::RUST_ENTRY = "_ZN3std2rt10lang_start";
+const std::string Naming::RUST_LANG_START_INTERNAL =
+    "_ZN3std2rt19lang_start_internal";
 const std::vector<std::string> Naming::RUST_PANICS = {
     "_ZN3std9panicking15begin_panic_fmt17h", "_ZN4core9panicking5panic17h",
     "_ZN3std9panicking11begin_panic17h", "_ZN4core9panicking9panic_fmt17h",

--- a/lib/smack/RustFixes.cpp
+++ b/lib/smack/RustFixes.cpp
@@ -1,0 +1,99 @@
+//
+// This file is distributed under the MIT License. See LICENSE for details.
+//
+// This patches Rust programs by removing certain language specific functions,
+// enabling later optimizations.
+//
+
+#include "smack/RustFixes.h"
+#include "smack/Naming.h"
+#include "llvm/Analysis/CallGraph.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/raw_ostream.h"
+#include <set>
+#include <string>
+
+namespace smack {
+
+using namespace llvm;
+
+/*
+The main function of rust programs looks like this:
+...
+%r = call i32 @std::rt::lang_start(..., @real_main, ...)
+...
+
+This patches the main function to:
+...
+%r = 0
+call void @real_main(...)
+...
+*/
+void fixEntry(Function &main) {
+  std::vector<Instruction *> instToErase;
+
+  for (inst_iterator I = inst_begin(main), E = inst_end(main); I != E; ++I) {
+    if (auto ci = dyn_cast<CallInst>(&*I)) {
+      if (Function *f = ci->getCalledFunction()) {
+        std::string name = f->hasName() ? f->getName() : "";
+        if (name.find(Naming::RUST_ENTRY) != std::string::npos) {
+          // Get real Rust main
+          auto castExpr = ci->getArgOperand(0);
+          auto mainFunction = cast<Function>(castExpr);
+          auto callMain = CallInst::Create(mainFunction->getFunctionType(),
+                                           cast<Value>(mainFunction));
+
+          // Replace the call to lang_start with the real Rust main function
+          auto retType = f->getReturnType();
+          // Create a fake return value for this instruction
+          Constant *zero = ConstantInt::get(retType, 0);
+          auto *result = BinaryOperator::Create(Instruction::Add, zero, zero);
+          result->insertAfter(ci);
+          // Call the real main function
+          callMain->insertAfter(result);
+          I->replaceAllUsesWith(result);
+
+          instToErase.push_back(&*I);
+        }
+      }
+    }
+  }
+
+  for (auto I : instToErase) {
+    I->eraseFromParent();
+  }
+}
+
+bool RustFixes::runOnModule(Module &m) {
+  std::set<Function *> funcToErase;
+
+  for (auto &F : m) {
+    if (F.hasName()) {
+      auto name = F.getName();
+      if (Naming::isSmackName(name))
+        continue;
+      if (name == "main") {
+        fixEntry(F);
+      } else if (name.find(Naming::RUST_LANG_START_INTERNAL) !=
+                     std::string::npos ||
+                 name.find(Naming::RUST_ENTRY) != std::string::npos) {
+        funcToErase.insert(&F);
+      }
+    }
+  }
+
+  for (auto F : funcToErase) {
+    F->dropAllReferences();
+  }
+
+  return true;
+}
+
+// Pass ID variable
+char RustFixes::ID = 0;
+
+StringRef RustFixes::getPassName() const { return "Fixes for Rust programs"; }
+
+} // namespace smack

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -659,12 +659,6 @@ void SmackInstGenerator::visitCallInst(llvm::CallInst &ci) {
                                ci.getType()->isVoidTy());
     emit(Stmt::skip());
 
-  } else if (name.find(Naming::RUST_ENTRY) != std::string::npos) {
-    // Set the entry point for Rust programs
-    auto castExpr = ci.getArgOperand(0);
-    auto mainFunction = cast<const Function>(castExpr);
-    emit(Stmt::call(mainFunction->getName(), {}, {}));
-
   } else if (SmackOptions::RustPanics && isRustPanic(name)) {
     // Convert Rust's panic functions into assertion violations
     emit(Stmt::assert_(Expr::lit(false),

--- a/tools/llvm2bpl/llvm2bpl.cpp
+++ b/tools/llvm2bpl/llvm2bpl.cpp
@@ -35,6 +35,7 @@
 #include "smack/MemorySafetyChecker.h"
 #include "smack/NormalizeLoops.h"
 #include "smack/RemoveDeadDefs.h"
+#include "smack/RustFixes.h"
 #include "smack/SimplifyLibCalls.h"
 #include "smack/SmackModuleGenerator.h"
 #include "smack/SmackOptions.h"
@@ -153,6 +154,10 @@ int main(int argc, char **argv) {
   llvm::initializeRemovePtrToIntPass(Registry);
 
   llvm::legacy::PassManager pass_manager;
+
+  // This runs before DSA because some Rust functions cause problems.
+  pass_manager.add(new smack::RustFixes);
+  pass_manager.add(llvm::createDeadCodeEliminationPass());
 
   pass_manager.add(seadsa::createRemovePtrToIntPass());
   pass_manager.add(llvm::createLowerSwitchPass());


### PR DESCRIPTION
- Removes the call to lang_start in the main function at the IR level
  * This enables certain optimizations that are not available when rewriting
    at the bpl level
- Remove lang_start functions from the IR
  * This allows dead code elimination to remove some globals that slow
    verification