### PR TITLE
Colorize rustc's output

### DIFF
--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -331,7 +331,8 @@ def default_rust_compile_args(args):
             '--cfg',
             'verifier="smack"',
             '-C',
-            'passes=name-anon-globals']
+            'passes=name-anon-globals',
+            '--color=always']
 
 
 def default_rust_compile_command(args):


### PR DESCRIPTION
This PR colorized the forwarded rustc's output so that it's easier to capture the errors in a compilation error message.