### PR TITLE
Fix smack crate installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,11 +217,11 @@ INSTALL(FILES
 INSTALL(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/share/smack/include/smack.h
   ${CMAKE_CURRENT_SOURCE_DIR}/share/smack/lib/smack.c
-  DESTINATION share/smack/smack/src
+  DESTINATION share/smack/lib/smack/src
 )
 
 INSTALL(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/share/smack/lib/smack.rs
-  DESTINATION share/smack/smack/src
+  DESTINATION share/smack/lib/smack/src
   RENAME lib.rs
 )

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -63,7 +63,7 @@ CONFIGURE_INSTALL_PREFIX=
 CMAKE_INSTALL_PREFIX=
 
 # Partial list of dependencies; the rest are added depending on the platform
-DEPENDENCIES="git cmake python3-yaml python3-psutil unzip wget ninja-build apt-transport-https dotnet-sdk-3.1 libboost-all-dev"
+DEPENDENCIES="git cmake python3-yaml python3-psutil python3-toml unzip wget ninja-build apt-transport-https dotnet-sdk-3.1 libboost-all-dev"
 
 shopt -s extglob
 


### PR DESCRIPTION
This fixes an issue where some files and dependencies weren't installed correctly, because of an erroneous merge.