### PR TITLE
Fixes for cargo builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,13 +217,18 @@ INSTALL(FILES
 )
 
 INSTALL(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/share/smack/include/smack.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/share/smack/lib/smack.c
-  DESTINATION share/smack/smack/src
+  ${CMAKE_CURRENT_SOURCE_DIR}/share/smack/lib/smack/Cargo.toml
+  ${CMAKE_CURRENT_SOURCE_DIR}/share/smack/lib/smack/build.rs
+  DESTINATION share/smack/lib
+)
+
+INSTALL(FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/share/smack/lib/smack-rust.c
+  DESTINATION share/smack/lib/src
 )
 
 INSTALL(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/share/smack/lib/smack.rs
-  DESTINATION share/smack/smack/src
+  DESTINATION share/smack/lib/src
   RENAME lib.rs
 )

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -63,7 +63,7 @@ CONFIGURE_INSTALL_PREFIX=
 CMAKE_INSTALL_PREFIX=
 
 # Partial list of dependencies; the rest are added depending on the platform
-DEPENDENCIES="git cmake python3-yaml python3-psutil unzip wget ninja-build apt-transport-https dotnet-sdk-3.1 libboost-all-dev"
+DEPENDENCIES="git cmake python3-yaml python3-psutil python3-toml unzip wget ninja-build apt-transport-https dotnet-sdk-3.1 libboost-all-dev"
 
 shopt -s extglob
 

--- a/examples/rust-cargo/Cargo.toml
+++ b/examples/rust-cargo/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-smack = { path = "/usr/local/share/smack/lib/smack" }
+smack = { path = "/usr/local/share/smack/lib" }
 
 [profile.dev]
 incremental=false

--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -367,7 +367,7 @@ def rust_frontend(input_file, args):
 def default_build_libs(args):
     """Generate LLVM bitcodes for SMACK libraries."""
     bitcodes = []
-    libs = ['smack.c', 'stdlib.c', 'errno.c']
+    libs = ['smack.c', 'stdlib.c', 'errno.c', 'smack-rust.c']
 
     if args.pthread:
         libs += ['pthread.c']

--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -87,11 +87,6 @@ void __VERIFIER_assert(int);
 #define U(...) TY(__VA_ARGS__, U4, U3, U2, U1)(__VA_ARGS__)
 
 #define NONDET_DECL(P, ty...) S(ty) U(P, U(ty))(void)
-#define EMPTY_NONDET_DEFN(P, ty...)                                            \
-  S(ty) U(P, U(ty))(void) {                                                    \
-    ty x;                                                                      \
-    return x;                                                                  \
-  }
 
 void *__VERIFIER_nondet(void);
 NONDET_DECL(__SMACK_nondet, char);

--- a/share/smack/lib/smack-rust.c
+++ b/share/smack/lib/smack-rust.c
@@ -1,0 +1,49 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#define mk_signed_type(size) int##size##_t
+#define mk_unsigned_type(size) uint##size##_t
+
+#define mk_signed_min(size) INT##size##_MIN
+#define mk_signed_max(size) INT##size##_MAX
+#define mk_unsigned_min(size) 0
+#define mk_unsigned_max(size) UINT##size##_MAX
+
+#define mk_smack_signed_nondet(size) __SMACK_nondet_i##size
+#define mk_smack_unsigned_nondet(size) __SMACK_nondet_u##size
+#define mk_smack_nondet_decl(size)                                             \
+  mk_signed_type(size) mk_smack_signed_nondet(size)(void);                     \
+  mk_unsigned_type(size) mk_smack_unsigned_nondet(size)(void);
+
+#define mk_smack_nondet_def(size)                                              \
+  mk_signed_type(size) __VERIFIER_nondet_i##size(void) {                       \
+    mk_signed_type(size) ret = mk_smack_signed_nondet(size)();                 \
+    if (ret < mk_signed_min(size) || ret > mk_signed_max(size))                \
+      abort();                                                                 \
+    return ret;                                                                \
+  }                                                                            \
+  mk_unsigned_type(size) __VERIFIER_nondet_u##size(void) {                     \
+    mk_unsigned_type(size) ret = mk_smack_unsigned_nondet(size)();             \
+    if (ret < mk_unsigned_min(size) || ret > mk_unsigned_max(size))            \
+      abort();                                                                 \
+    return ret;                                                                \
+  }
+
+#define mk_dummy_nondet_def(size)                                              \
+  mk_signed_type(size) __VERIFIER_nondet_i##size(void) {                       \
+    return *((mk_signed_type(size) *)malloc(sizeof(mk_signed_type(size))));    \
+  }                                                                            \
+  mk_unsigned_type(size) __VERIFIER_nondet_u##size(void) {                     \
+    return *(                                                                  \
+        (mk_unsigned_type(size) *)malloc(sizeof(mk_unsigned_type(size))));     \
+  }
+
+#if CARGO_BUILD
+mk_dummy_nondet_def(8) mk_dummy_nondet_def(16) mk_dummy_nondet_def(32)
+    mk_dummy_nondet_def(64) void __VERIFIER_assert(int x) {}
+void __VERIFIER_assume(int x) {}
+#else
+mk_smack_nondet_decl(8) mk_smack_nondet_decl(16) mk_smack_nondet_decl(32)
+    mk_smack_nondet_decl(64) mk_smack_nondet_def(8) mk_smack_nondet_def(16)
+        mk_smack_nondet_def(32) mk_smack_nondet_def(64)
+#endif

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -41,49 +41,18 @@ void *__builtinx_va_arg(char *x) {
 long __builtinx_expect(long exp, long c) { return exp; }
 
 void __VERIFIER_assume(int x) {
-#if !RUST_EXEC
   __SMACK_dummy(x);
   __SMACK_code("assume @ != $0;", x);
-#endif
 }
 
 #ifndef CUSTOM_VERIFIER_ASSERT
 void __VERIFIER_assert(int x) {
-#if !DISABLE_SMACK_ASSERTIONS && !RUST_EXEC
+#if !DISABLE_SMACK_ASSERTIONS
   __SMACK_dummy(x);
   __SMACK_code("assert @ != $0;", x);
 #endif
 }
 #endif
-
-#if RUST_EXEC
-// Enable compatibility with Cargo compilation.
-EMPTY_NONDET_DEFN(__SMACK_nondet, char);
-EMPTY_NONDET_DEFN(__SMACK_nondet, signed, char);
-EMPTY_NONDET_DEFN(__SMACK_nondet, unsigned, char);
-EMPTY_NONDET_DEFN(__SMACK_nondet, short);
-EMPTY_NONDET_DEFN(__SMACK_nondet, short, int);
-EMPTY_NONDET_DEFN(__SMACK_nondet, signed, short);
-EMPTY_NONDET_DEFN(__SMACK_nondet, signed, short, int);
-EMPTY_NONDET_DEFN(__SMACK_nondet, unsigned, short);
-EMPTY_NONDET_DEFN(__SMACK_nondet, unsigned, short, int);
-EMPTY_NONDET_DEFN(__SMACK_nondet, int);
-EMPTY_NONDET_DEFN(__SMACK_nondet, signed, int);
-EMPTY_NONDET_DEFN(__SMACK_nondet, unsigned);
-EMPTY_NONDET_DEFN(__SMACK_nondet, unsigned, int);
-EMPTY_NONDET_DEFN(__SMACK_nondet, long);
-EMPTY_NONDET_DEFN(__SMACK_nondet, long, int);
-EMPTY_NONDET_DEFN(__SMACK_nondet, signed, long);
-EMPTY_NONDET_DEFN(__SMACK_nondet, signed, long, int);
-EMPTY_NONDET_DEFN(__SMACK_nondet, unsigned, long);
-EMPTY_NONDET_DEFN(__SMACK_nondet, unsigned, long, int);
-EMPTY_NONDET_DEFN(__SMACK_nondet, long, long);
-EMPTY_NONDET_DEFN(__SMACK_nondet, long, long, int);
-EMPTY_NONDET_DEFN(__SMACK_nondet, signed, long, long);
-EMPTY_NONDET_DEFN(__SMACK_nondet, signed, long, long, int);
-EMPTY_NONDET_DEFN(__SMACK_nondet, unsigned, long, long);
-EMPTY_NONDET_DEFN(__SMACK_nondet, unsigned, long, long, int);
-#endif // RUST_EXEC
 
 int __SMACK_and32(int a, int b) {
   int c = 0;

--- a/share/smack/lib/smack.rs
+++ b/share/smack/lib/smack.rs
@@ -4,14 +4,14 @@
 extern "C" {
     pub fn __VERIFIER_assert(x: i32);
     pub fn __VERIFIER_assume(x: i32);
-    pub fn __VERIFIER_nondet_signed_char() -> i8;
-    pub fn __VERIFIER_nondet_unsigned_char() -> u8;
-    pub fn __VERIFIER_nondet_signed_short() -> i16;
-    pub fn __VERIFIER_nondet_unsigned_short() -> u16;
-    pub fn __VERIFIER_nondet_signed_int() -> i32;
-    pub fn __VERIFIER_nondet_unsigned_int() -> u32;
-    pub fn __VERIFIER_nondet_signed_long_long() -> i64;
-    pub fn __VERIFIER_nondet_unsigned_long_long() -> u64;
+    pub fn __VERIFIER_nondet_i8() -> i8;
+    pub fn __VERIFIER_nondet_u8() -> u8;
+    pub fn __VERIFIER_nondet_i16() -> i16;
+    pub fn __VERIFIER_nondet_u16() -> u16;
+    pub fn __VERIFIER_nondet_i32() -> i32;
+    pub fn __VERIFIER_nondet_u32() -> u32;
+    pub fn __VERIFIER_nondet_i64() -> i64;
+    pub fn __VERIFIER_nondet_u64() -> u64;
     pub fn malloc(size: usize) -> *mut u8;
     pub fn __VERIFIER_memcpy(dest: *mut u8, src: *mut u8, count: usize) -> *mut u8;
     pub fn free(ptr: *mut u8);
@@ -129,16 +129,16 @@ macro_rules! make_verifier_nondet {
 }
 
 /* Instantiate nondet for all integer types. */
-make_verifier_nondet!(i8, __VERIFIER_nondet_signed_char);
-make_verifier_nondet!(u8, __VERIFIER_nondet_unsigned_char);
-make_verifier_nondet!(i16, __VERIFIER_nondet_signed_short);
-make_verifier_nondet!(u16, __VERIFIER_nondet_unsigned_short);
-make_verifier_nondet!(i32, __VERIFIER_nondet_signed_int);
-make_verifier_nondet!(u32, __VERIFIER_nondet_unsigned_int);
-make_verifier_nondet!(i64, __VERIFIER_nondet_signed_long_long);
-make_verifier_nondet!(u64, __VERIFIER_nondet_unsigned_long_long);
-make_verifier_nondet!(isize, __VERIFIER_nondet_signed_long_long);
-make_verifier_nondet!(usize, __VERIFIER_nondet_unsigned_long_long);
+make_verifier_nondet!(i8, __VERIFIER_nondet_i8);
+make_verifier_nondet!(u8, __VERIFIER_nondet_u8);
+make_verifier_nondet!(i16, __VERIFIER_nondet_i16);
+make_verifier_nondet!(u16, __VERIFIER_nondet_u16);
+make_verifier_nondet!(i32, __VERIFIER_nondet_i32);
+make_verifier_nondet!(u32, __VERIFIER_nondet_u32);
+make_verifier_nondet!(i64, __VERIFIER_nondet_i64);
+make_verifier_nondet!(u64, __VERIFIER_nondet_u64);
+make_verifier_nondet!(isize, __VERIFIER_nondet_i64);
+make_verifier_nondet!(usize, __VERIFIER_nondet_u64);
 
 #[cfg(not(verifier = "smack"))]
 #[cfg(feature = "std")]

--- a/share/smack/lib/smack/build.rs
+++ b/share/smack/lib/smack/build.rs
@@ -2,11 +2,11 @@
 
 fn main() {
     cc::Build::new()
-        .file("src/smack.c")
-        .define("RUST_EXEC", None)
+        .file("src/smack-rust.c")
+        .define("CARGO_BUILD", None)
         .include("src")
         .compiler("clang")
         .compile("libsmack.a");
-    println!("cargo:rerun-if-changed=src/smack.c");
+    println!("cargo:rerun-if-changed=src/smack-rust.c");
 }
 

--- a/test/rust/cargo/cargo-test/Cargo.toml
+++ b/test/rust/cargo/cargo-test/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 num-traits = "0.2.12"
-smack = { path = "/usr/local/share/smack/lib/smack" }
+smack = { path = "/usr/local/share/smack/lib" }


### PR DESCRIPTION
This PR attempts to fix build issues when using cargo. The fixes/refactorings are,

* Split Rust's FFIs into a designated file named `smack-rust.c`. This allows us to decouple Rust-related C functions from SMACK's C libraries, which further enables uploading the SMACK crate to crates.io.

* Fix installation path issues.

* Install `Cargo.toml` and `build.rs`.