### PR TITLE
Fixed invalid translation/assertion failure related to inline assembly

### DIFF
--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -650,6 +650,7 @@ void SmackInstGenerator::visitCallInst(llvm::CallInst &ci) {
     SmackWarnings::warnUnsound("inline asm call " + i2s(ci), currBlock, &ci,
                                ci.getType()->isVoidTy());
     emit(Stmt::skip());
+    return;
   }
 
   Function *f = ci.getCalledFunction();

--- a/lib/utils/Devirt.cpp
+++ b/lib/utils/Devirt.cpp
@@ -456,7 +456,7 @@ Devirtualize::processCallSite (CallSite &CS) {
   // First, determine if this is a direct call.  If so, then just ignore it.
   //
   Value * CalledValue = CS.getCalledValue();
-  if (isa<Function>(CalledValue->stripPointerCastsAndAliases()))
+  if (!CS.isIndirectCall())
     return;
 
   //


### PR DESCRIPTION
Inline assembly with side effects do not have functions being called values.
This triggers invalid translation by the `Devirt` pass and assertion failure in
`SmackInstGenerator`.