### PR TITLE
Temporarily fixed LLVM intrinsics modeling

### DIFF
--- a/include/smack/SmackRep.h
+++ b/include/smack/SmackRep.h
@@ -130,7 +130,7 @@ public:
   std::string type(const llvm::Value *v);
 
   const Expr *lit(const llvm::Value *v, bool isUnsigned = false,
-                  bool isCmpInst = false);
+                  bool isUnsignedInst = false);
   const Expr *lit(const llvm::Value *v, unsigned flag);
 
   const Expr *ptrArith(const llvm::GetElementPtrInst *I);
@@ -140,7 +140,7 @@ public:
            std::vector<std::pair<llvm::Value *, llvm::gep_type_iterator>> args);
 
   const Expr *expr(const llvm::Value *v, bool isConstIntUnsigned = false,
-                   bool isCmpInst = false);
+                   bool isUnsignedInst = false);
 
   const Expr *cast(const llvm::Instruction *I);
   const Expr *cast(const llvm::ConstantExpr *CE);

--- a/lib/smack/IntegerOverflowChecker.cpp
+++ b/lib/smack/IntegerOverflowChecker.cpp
@@ -52,15 +52,12 @@ std::string IntegerOverflowChecker::getMin(unsigned bits, bool isSigned) {
  */
 Value *IntegerOverflowChecker::extendBitWidth(Value *v, int bits, bool isSigned,
                                               Instruction *i) {
-  if (SmackOptions::IntegerOverflow) {
-    if (isSigned)
-      return CastInst::CreateSExtOrBitCast(
-          v, IntegerType::get(i->getFunction()->getContext(), bits * 2), "", i);
-    else
-      return CastInst::CreateZExtOrBitCast(
-          v, IntegerType::get(i->getFunction()->getContext(), bits * 2), "", i);
-  } else
-    return v;
+  if (isSigned)
+    return CastInst::CreateSExtOrBitCast(
+        v, IntegerType::get(i->getFunction()->getContext(), bits * 2), "", i);
+  else
+    return CastInst::CreateZExtOrBitCast(
+        v, IntegerType::get(i->getFunction()->getContext(), bits * 2), "", i);
 }
 
 /*
@@ -70,24 +67,19 @@ Value *IntegerOverflowChecker::extendBitWidth(Value *v, int bits, bool isSigned,
 BinaryOperator *IntegerOverflowChecker::createFlag(Value *v, int bits,
                                                    bool isSigned,
                                                    Instruction *i) {
-  if (SmackOptions::IntegerOverflow) {
-    ConstantInt *max = ConstantInt::get(
-        IntegerType::get(i->getFunction()->getContext(), bits * 2),
-        getMax(bits, isSigned), 10);
-    ConstantInt *min = ConstantInt::get(
-        IntegerType::get(i->getFunction()->getContext(), bits * 2),
-        getMin(bits, isSigned), 10);
-    CmpInst::Predicate maxCmpPred =
-        (isSigned ? CmpInst::ICMP_SGT : CmpInst::ICMP_UGT);
-    CmpInst::Predicate minCmpPred =
-        (isSigned ? CmpInst::ICMP_SLT : CmpInst::ICMP_ULT);
-    ICmpInst *gt = new ICmpInst(i, maxCmpPred, v, max, "");
-    ICmpInst *lt = new ICmpInst(i, minCmpPred, v, min, "");
-    return BinaryOperator::Create(Instruction::Or, gt, lt, "", i);
-  } else {
-    ConstantInt *a = ConstantInt::getFalse(i->getFunction()->getContext());
-    return BinaryOperator::Create(Instruction::And, a, a, "", i);
-  }
+  ConstantInt *max = ConstantInt::get(
+      IntegerType::get(i->getFunction()->getContext(), bits * 2),
+      getMax(bits, isSigned), 10);
+  ConstantInt *min = ConstantInt::get(
+      IntegerType::get(i->getFunction()->getContext(), bits * 2),
+      getMin(bits, isSigned), 10);
+  CmpInst::Predicate maxCmpPred =
+      (isSigned ? CmpInst::ICMP_SGT : CmpInst::ICMP_UGT);
+  CmpInst::Predicate minCmpPred =
+      (isSigned ? CmpInst::ICMP_SLT : CmpInst::ICMP_ULT);
+  ICmpInst *gt = new ICmpInst(i, maxCmpPred, v, max, "");
+  ICmpInst *lt = new ICmpInst(i, minCmpPred, v, min, "");
+  return BinaryOperator::Create(Instruction::Or, gt, lt, "", i);
 }
 
 /*
@@ -95,11 +87,8 @@ BinaryOperator *IntegerOverflowChecker::createFlag(Value *v, int bits,
  */
 Value *IntegerOverflowChecker::createResult(Value *v, int bits,
                                             Instruction *i) {
-  if (SmackOptions::IntegerOverflow)
-    return CastInst::CreateTruncOrBitCast(
-        v, IntegerType::get(i->getFunction()->getContext(), bits), "", i);
-  else
-    return v;
+  return CastInst::CreateTruncOrBitCast(
+      v, IntegerType::get(i->getFunction()->getContext(), bits), "", i);
 }
 
 /*
@@ -196,7 +185,7 @@ bool IntegerOverflowChecker::runOnModule(Module &m) {
                     ei->replaceAllUsesWith(r);
                   else if (ei->getIndices()[0] == 1) {
                     // flag part
-                    addBlockingAssume(va, flag, ei);
+                    // addBlockingAssume(va, flag, ei);
                     ei->replaceAllUsesWith(flag);
                   } else
                     llvm_unreachable("Unexpected extractvalue inst!");

--- a/lib/smack/RewriteBitwiseOps.cpp
+++ b/lib/smack/RewriteBitwiseOps.cpp
@@ -78,8 +78,7 @@ bool RewriteBitwiseOps::runOnModule(Module &m) {
           instsFrom.push_back(&*I);
           instsTo.push_back(replacement);
         }
-      }
-      if (I->isBitwiseLogicOp()) {
+      } else if (I->isBitwiseLogicOp()) {
         // If the operation is a bit-wise `and' and the mask variable is
         // constant, it may be possible to replace this operation with a
         // remainder operation. If one argument has only ones, and they're only
@@ -109,6 +108,8 @@ bool RewriteBitwiseOps::runOnModule(Module &m) {
               co = m.getFunction("__SMACK_and16");
             } else if (bitWidth == 8) {
               co = m.getFunction("__SMACK_and8");
+            } else if (bitWidth == 1) {
+              continue;
             } else {
               co = m.getFunction("__SMACK_and32");
             }
@@ -136,6 +137,8 @@ bool RewriteBitwiseOps::runOnModule(Module &m) {
             co = m.getFunction("__SMACK_or16");
           } else if (bitWidth == 8) {
             co = m.getFunction("__SMACK_or8");
+          } else if (bitWidth == 1) {
+            continue;
           } else {
             co = m.getFunction("__SMACK_or32");
           }

--- a/lib/smack/SmackRep.cpp
+++ b/lib/smack/SmackRep.cpp
@@ -926,7 +926,8 @@ const Expr *SmackRep::bop(unsigned opcode, const llvm::Value *lhs,
   if (opcode == llvm::Instruction::SDiv || opcode == llvm::Instruction::SRem) {
     isUnsigned = false;
   } else if (opcode == llvm::Instruction::UDiv ||
-             opcode == llvm::Instruction::URem) {
+             opcode == llvm::Instruction::URem ||
+             opcode == llvm::Instruction::Sub) {
     isUnsigned = true;
   }
 
@@ -939,8 +940,8 @@ const Expr *SmackRep::bop(unsigned opcode, const llvm::Value *lhs,
       return Expr::fn(opName(fn, {t}), expr(lhs), expr(rhs));
     }
   }
-  return Expr::fn(opName(fn, {t}), expr(lhs, isUnsigned),
-                  expr(rhs, isUnsigned));
+  return Expr::fn(opName(fn, {t}), expr(lhs, isUnsigned, opcode == llvm::Instruction::Sub),
+                  expr(rhs, isUnsigned, opcode == llvm::Instruction::Sub));
 }
 
 const Expr *SmackRep::uop(const llvm::ConstantExpr *CE) {

--- a/lib/smack/SmackRep.cpp
+++ b/lib/smack/SmackRep.cpp
@@ -940,7 +940,8 @@ const Expr *SmackRep::bop(unsigned opcode, const llvm::Value *lhs,
       return Expr::fn(opName(fn, {t}), expr(lhs), expr(rhs));
     }
   }
-  return Expr::fn(opName(fn, {t}), expr(lhs, isUnsigned, opcode == llvm::Instruction::Sub),
+  return Expr::fn(opName(fn, {t}),
+                  expr(lhs, isUnsigned, opcode == llvm::Instruction::Sub),
                   expr(rhs, isUnsigned, opcode == llvm::Instruction::Sub));
 }
 
@@ -991,7 +992,9 @@ const Expr *SmackRep::select(const llvm::ConstantExpr *CE) {
 const Expr *SmackRep::select(const llvm::Value *condVal,
                              const llvm::Value *trueVal,
                              const llvm::Value *falseVal) {
-  const Expr *c = expr(condVal), *v1 = expr(trueVal), *v2 = expr(falseVal);
+  const Expr *c = expr(condVal);
+  const Expr *v1 = expr(trueVal, true, true);
+  const Expr *v2 = expr(falseVal, true, true);
 
   assert(!condVal->getType()->isVectorTy() &&
          "Vector condition is not supported.");

--- a/lib/smack/SmackRep.cpp
+++ b/lib/smack/SmackRep.cpp
@@ -625,7 +625,7 @@ const Expr *SmackRep::integerLit(long long v, unsigned width) {
 }
 
 const Expr *SmackRep::lit(const llvm::Value *v, bool isUnsigned,
-                          bool isCmpInst) {
+                          bool isUnsignedInst) {
   using namespace llvm;
 
   if (const ConstantInt *ci = llvm::dyn_cast<const ConstantInt>(v)) {
@@ -638,7 +638,7 @@ const Expr *SmackRep::lit(const llvm::Value *v, bool isUnsigned,
     // gets translated into i + (-1), and so in that context it should
     // be a signed integer.
     bool neg = width > 1 &&
-               (isUnsigned ? (isCmpInst ? false : API.getSExtValue() == -1)
+               (isUnsigned ? (isUnsignedInst ? false : API.getSExtValue() == -1)
                            : ci->isNegative());
     std::string str = (neg ? API.abs() : API).toString(10, false);
     const Expr *e =
@@ -794,7 +794,7 @@ const Expr *SmackRep::ptrArith(
 }
 
 const Expr *SmackRep::expr(const llvm::Value *v, bool isConstIntUnsigned,
-                           bool isCmpInst) {
+                           bool isUnsignedInst) {
   using namespace llvm;
 
   if (isa<const Constant>(v)) {
@@ -837,7 +837,7 @@ const Expr *SmackRep::expr(const llvm::Value *v, bool isConstIntUnsigned,
       }
 
     } else if (const ConstantInt *ci = dyn_cast<const ConstantInt>(constant)) {
-      return lit(ci, isConstIntUnsigned, isCmpInst);
+      return lit(ci, isConstIntUnsigned, isUnsignedInst);
 
     } else if (const ConstantFP *cf = dyn_cast<const ConstantFP>(constant)) {
       return lit(cf);
@@ -943,8 +943,7 @@ const Expr *SmackRep::bop(unsigned opcode, const llvm::Value *lhs,
     isUnsigned = true;
   }
 
-  return Expr::fn(opName(fn, {t}),
-                  expr(lhs, isUnsigned, isUnsignedInst),
+  return Expr::fn(opName(fn, {t}), expr(lhs, isUnsigned, isUnsignedInst),
                   expr(rhs, isUnsigned, isUnsignedInst));
 }
 

--- a/share/smack/include/smack.h
+++ b/share/smack/include/smack.h
@@ -21,6 +21,7 @@ extern "C" {
 #define __builtin_va_start __builtinx_va_start
 #define __builtin_va_arg(ap, t) __builtinx_va_arg(ap)
 #define __builtin_object_size __builtinx_object_size
+#define __builtin_expect __builtinx_expect
 
 // For handling of va macros
 void __builtinx_va_start(char *, char *);

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -38,7 +38,7 @@ void *__builtinx_va_arg(char *x) {
   return 0;
 }
 
-long __builtin_expect(long exp, long c) { return exp; }
+long __builtinx_expect(long exp, long c) { return exp; }
 
 void __VERIFIER_assume(int x) {
 #if !RUST_EXEC

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -38,9 +38,7 @@ void *__builtinx_va_arg(char *x) {
   return 0;
 }
 
-long __builtin_expect(long exp, long c) {
-  return exp;
-}
+long __builtin_expect(long exp, long c) { return exp; }
 
 void __VERIFIER_assume(int x) {
 #if !RUST_EXEC

--- a/share/smack/lib/smack.c
+++ b/share/smack/lib/smack.c
@@ -38,6 +38,10 @@ void *__builtinx_va_arg(char *x) {
   return 0;
 }
 
+long __builtin_expect(long exp, long c) {
+  return exp;
+}
+
 void __VERIFIER_assume(int x) {
 #if !RUST_EXEC
   __SMACK_dummy(x);


### PR DESCRIPTION
This commit always enables precise modeling of the overflow flag and does not
inject blocking assumes.