### PR TITLE
Do not emit warnings about bitwise operations of bit-width 1

### DIFF
--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -351,7 +351,7 @@ void SmackInstGenerator::visitUnreachableInst(llvm::UnreachableInst &ii) {
 
 void SmackInstGenerator::visitBinaryOperator(llvm::BinaryOperator &I) {
   processInstruction(I);
-  if (rep->isBitwiseOp(&I))
+  if (rep->isBitwiseOp(&I) && I.getType()->getIntegerBitWidth() > 1)
     SmackWarnings::warnIfUnsound(std::string("bitwise operation ") +
                                      I.getOpcodeName(),
                                  SmackOptions::BitPrecise, currBlock, &I);


### PR DESCRIPTION
We have precisely modeled them using axioms.