### PR TITLE
Refactored warning message APIs

### DIFF
--- a/include/smack/SmackInstGenerator.h
+++ b/include/smack/SmackInstGenerator.h
@@ -47,8 +47,6 @@ private:
   const Stmt *recordProcedureCall(const llvm::Value *V,
                                   std::list<const Attr *> attrs);
 
-  void generateUnModeledCall(llvm::CallInst *ci);
-
 public:
   void emit(const Stmt *s);
 

--- a/include/smack/SmackWarnings.h
+++ b/include/smack/SmackWarnings.h
@@ -22,8 +22,8 @@ class SmackWarnings {
 public:
   enum class WarningLevel : unsigned {
     Silent = 0,
-    Unsound = 10, // Unhandled intrinsics, asm, etc
-    Info = 20     // Memory length, etc.
+    Imprecise = 10, // Unhandled intrinsics, asm, etc
+    Info = 20       // Memory length, etc.
   };
 
   enum class FlagRelation : unsigned { And = 0, Or = 1 };
@@ -31,23 +31,19 @@ public:
   static UnsetFlagsT getUnsetFlags(RequiredFlagsT flags);
   static bool isSatisfied(RequiredFlagsT flags, FlagRelation rel);
 
-  // generate warnings about unsoundness
-  static void warnUnsound(std::string unmodeledOpName, Block *currBlock,
-                          const llvm::Instruction *i, bool ignore = false,
-                          FlagRelation rel = FlagRelation::And);
-  static void warnUnsound(std::string name, UnsetFlagsT unsetFlags,
-                          Block *currBlock, const llvm::Instruction *i,
-                          bool ignore = false,
-                          FlagRelation rel = FlagRelation::And);
-  static void warnIfUnsound(std::string name, RequiredFlagsT requiredFlags,
-                            Block *currBlock, const llvm::Instruction *i,
-                            bool ignore = false,
-                            FlagRelation rel = FlagRelation::And);
-  static void warnIfUnsound(std::string name, FlagT &requiredFlag,
-                            Block *currBlock, const llvm::Instruction *i,
-                            FlagRelation rel = FlagRelation::And);
-  static void warnIfUnsound(std::string name, FlagT &requiredFlag1,
-                            FlagT &requiredFlag2, Block *currBlock,
+  static void warnUnModeled(std::string unmodeledOpName, Block *currBlock,
+                            const llvm::Instruction *i);
+
+  static void warnIfIncomplete(std::string name, RequiredFlagsT requiredFlags,
+                               Block *currBlock, const llvm::Instruction *i,
+                               FlagRelation rel = FlagRelation::And);
+
+  static void warnIfIncomplete(std::string name, UnsetFlagsT unsetFlags,
+                               Block *currBlock, const llvm::Instruction *i,
+                               FlagRelation rel);
+
+  static void warnImprecise(std::string name, std::string description,
+                            UnsetFlagsT unsetFlags, Block *currBlock,
                             const llvm::Instruction *i,
                             FlagRelation rel = FlagRelation::And);
 

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -316,13 +316,11 @@ void SmackInstGenerator::visitSwitchInst(llvm::SwitchInst &si) {
 void SmackInstGenerator::visitInvokeInst(llvm::InvokeInst &ii) {
   processInstruction(ii);
   llvm::Function *f = ii.getCalledFunction();
-  if (f) {
+  if (f)
     emit(rep->call(f, ii));
-  } else {
+  else
     llvm_unreachable("Unexpected invoke instruction.");
-    // SmackWarnings::warnUnsound("invoke instruction", currBlock, &ii,
-    //                           ii.getType()->isVoidTy());
-  }
+
   std::vector<std::pair<const Expr *, llvm::BasicBlock *>> targets;
   targets.push_back(
       {Expr::not_(Expr::id(Naming::EXN_VAR)), ii.getNormalDest()});

--- a/lib/smack/SmackOptions.cpp
+++ b/lib/smack/SmackOptions.cpp
@@ -14,14 +14,14 @@ const llvm::cl::list<std::string>
 
 const llvm::cl::opt<SmackWarnings::WarningLevel> SmackOptions::WarningLevel(
     "warn-type", llvm::cl::desc("Enable certain type of warning messages."),
-    llvm::cl::values(
-        clEnumValN(SmackWarnings::WarningLevel::Silent, "silent",
-                   "No warning messages"),
-        clEnumValN(SmackWarnings::WarningLevel::Unsound, "unsound",
-                   "Enable warnings about unsoundness"),
-        clEnumValN(
-            SmackWarnings::WarningLevel::Info, "info",
-            "Enable warnings about unsoundness and translation information")));
+    llvm::cl::values(clEnumValN(SmackWarnings::WarningLevel::Silent, "silent",
+                                "No warning messages"),
+                     clEnumValN(SmackWarnings::WarningLevel::Imprecise,
+                                "imprecise",
+                                "Enable warnings about imprecise modeling"),
+                     clEnumValN(SmackWarnings::WarningLevel::Info, "info",
+                                "Enable warnings about imprecise modeling and "
+                                "translation information")));
 
 const llvm::cl::opt<bool> SmackOptions::ColoredWarnings(
     "colored-warnings", llvm::cl::desc("Enable colored warning messages."));

--- a/lib/smack/SmackRep.cpp
+++ b/lib/smack/SmackRep.cpp
@@ -857,8 +857,8 @@ const Expr *SmackRep::expr(const llvm::Value *v, bool isConstIntUnsigned,
     }
 
   } else if (isa<InlineAsm>(v)) {
-    SmackWarnings::warnUnsound("inline asm passed as argument", nullptr,
-                               nullptr);
+    SmackWarnings::warnUnModeled("inline asm passed as argument", nullptr,
+                                 nullptr);
     return pointerLit(0ULL);
 
   } else {

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -309,12 +309,12 @@ def arguments():
         type=str,
         help='limit debugging output to given MODULES')
 
-    noise_group.add_argument('--warn', default="unsound",
-                             choices=['silent', 'unsound', 'info'],
+    noise_group.add_argument('--warn', default="imprecise",
+                             choices=['silent', 'imprecise', 'info'],
                              help='''enable certain type of warning messages
             (silent: no warning messages;
-            unsound: warnings about unsoundness;
-            info: warnings about unsoundness and translation information)
+            unsound: warnings about imprecise modeling;
+            info: warnings about imprecise modeling/translation information)
             [default: %(default)s]''')
 
     parser.add_argument(


### PR DESCRIPTION
This commit changes incorrectly named `warn.*Unsound` into `warnIfIncomplete` or
`warnUnModeled` to better reflect their meanings. In the meanwhile, the
incorretly named warning level `unsound` gets changed to `imprecise`.

Fixes #614