### PR TITLE
Rewrite undef pointers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ add_library(smackTranslator STATIC
   include/smack/SplitAggregateValue.h
   include/smack/Prelude.h
   include/smack/SmackWarnings.h
+  include/smack/RemoveUndefPtrs.h
   lib/smack/AddTiming.cpp
   lib/smack/BoogieAst.cpp
   lib/smack/BplFilePrinter.cpp
@@ -163,6 +164,7 @@ add_library(smackTranslator STATIC
   lib/smack/SplitAggregateValue.cpp
   lib/smack/Prelude.cpp
   lib/smack/SmackWarnings.cpp
+  lib/smack/RemoveUndefPtrs.cpp
 )
 
 add_executable(llvm2bpl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,12 +132,12 @@ add_library(smackTranslator STATIC
   include/smack/MemorySafetyChecker.h
   include/smack/IntegerOverflowChecker.h
   include/smack/RewriteBitwiseOps.h
+  include/smack/RewriteUndefPtrs.h
   include/smack/NormalizeLoops.h
   include/smack/RustFixes.h
   include/smack/SplitAggregateValue.h
   include/smack/Prelude.h
   include/smack/SmackWarnings.h
-  include/smack/RemoveUndefPtrs.h
   lib/smack/AddTiming.cpp
   lib/smack/BoogieAst.cpp
   lib/smack/BplFilePrinter.cpp
@@ -164,7 +164,7 @@ add_library(smackTranslator STATIC
   lib/smack/SplitAggregateValue.cpp
   lib/smack/Prelude.cpp
   lib/smack/SmackWarnings.cpp
-  lib/smack/RemoveUndefPtrs.cpp
+  lib/smack/RewriteUndefPtrs.cpp
 )
 
 add_executable(llvm2bpl

--- a/include/smack/RemoveUndefPtrs.h
+++ b/include/smack/RemoveUndefPtrs.h
@@ -1,0 +1,29 @@
+//
+// This file is distributed under the MIT License. See LICENSE for details.
+//
+#ifndef REMOVEUNDEFPTRS_H
+#define REMOVEUNDEFPTRS_H
+
+#include "llvm/IR/Instructions.h"
+#include "llvm/Pass.h"
+
+namespace smack {
+using namespace llvm;
+
+class RemoveUndefPtrs : public FunctionPass {
+
+  enum Flags { NO_TIMING_INFO = -1 };
+  static const std::string INT_TIMING_COST_METADATA;
+  static const std::string INSTRUCTION_NAME_METADATA;
+
+public:
+  static char ID; // Class identification, replacement for typeinfo
+  RemoveUndefPtrs() : FunctionPass(ID) {}
+
+private:
+  bool runOnFunction(Function &F) override;
+};
+
+} // namespace smack
+
+#endif // REMOVEUNDEFPTRS_H

--- a/include/smack/RewriteUndefPtrs.h
+++ b/include/smack/RewriteUndefPtrs.h
@@ -1,8 +1,8 @@
 //
 // This file is distributed under the MIT License. See LICENSE for details.
 //
-#ifndef REMOVEUNDEFPTRS_H
-#define REMOVEUNDEFPTRS_H
+#ifndef REWRITEUNDEFPTRS_H
+#define REWRITEUNDEFPTRS_H
 
 #include "llvm/IR/Instructions.h"
 #include "llvm/Pass.h"
@@ -10,7 +10,7 @@
 namespace smack {
 using namespace llvm;
 
-class RemoveUndefPtrs : public FunctionPass {
+class RewriteUndefPtrs : public FunctionPass {
 
   enum Flags { NO_TIMING_INFO = -1 };
   static const std::string INT_TIMING_COST_METADATA;
@@ -18,7 +18,7 @@ class RemoveUndefPtrs : public FunctionPass {
 
 public:
   static char ID; // Class identification, replacement for typeinfo
-  RemoveUndefPtrs() : FunctionPass(ID) {}
+  RewriteUndefPtrs() : FunctionPass(ID) {}
 
 private:
   bool runOnFunction(Function &F) override;
@@ -26,4 +26,4 @@ private:
 
 } // namespace smack
 
-#endif // REMOVEUNDEFPTRS_H
+#endif // REWRITEUNDEFPTRS_H

--- a/include/smack/RewriteUndefPtrs.h
+++ b/include/smack/RewriteUndefPtrs.h
@@ -12,10 +12,6 @@ using namespace llvm;
 
 class RewriteUndefPtrs : public FunctionPass {
 
-  enum Flags { NO_TIMING_INFO = -1 };
-  static const std::string INT_TIMING_COST_METADATA;
-  static const std::string INSTRUCTION_NAME_METADATA;
-
 public:
   static char ID; // Class identification, replacement for typeinfo
   RewriteUndefPtrs() : FunctionPass(ID) {}

--- a/include/smack/SmackOptions.h
+++ b/include/smack/SmackOptions.h
@@ -26,6 +26,7 @@ public:
   static llvm::cl::opt<bool> BitPrecise;
   static const llvm::cl::opt<bool> BitPrecisePointers;
   static const llvm::cl::opt<bool> RewriteBitwiseOps;
+  static const llvm::cl::opt<bool> RewriteUndefPtrs;
   static const llvm::cl::opt<bool> NoMemoryRegionSplitting;
   static const llvm::cl::opt<bool> NoByteAccessInference;
   static const llvm::cl::opt<bool> FloatEnabled;

--- a/lib/smack/RemoveUndefPtrs.cpp
+++ b/lib/smack/RemoveUndefPtrs.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+#include "smack/RemoveUndefPtrs.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+namespace smack {
+
+char RemoveUndefPtrs::ID = 0;
+static RegisterPass<RemoveUndefPtrs>
+    X("remove-undef-ptrs", "Transform undef pointers into null pointers");
+
+bool RemoveUndefPtrs::runOnFunction(Function &F) {
+  bool changed = false;
+  for (inst_iterator I = inst_begin(F), E = inst_end(F); I != E; ++I) {
+    for (auto OI = I->op_begin(), OE = I->op_end(); OI != OE; ++OI) {
+      Value *val = OI->get();
+      if (auto *uv = dyn_cast<UndefValue>(val)) {
+        if (PointerType *uvpt = dyn_cast<PointerType>(uv->getType())) {
+          Value *replacement = ConstantPointerNull::get(uvpt);
+          *OI = replacement;
+          changed = true;
+        }
+      }
+    }
+  }
+
+  return changed;
+}
+
+} // namespace smack

--- a/lib/smack/RewriteUndefPtrs.cpp
+++ b/lib/smack/RewriteUndefPtrs.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//
-#include "smack/RemoveUndefPtrs.h"
+#include "smack/RewriteUndefPtrs.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -16,11 +16,11 @@ using namespace llvm;
 
 namespace smack {
 
-char RemoveUndefPtrs::ID = 0;
-static RegisterPass<RemoveUndefPtrs>
-    X("remove-undef-ptrs", "Transform undef pointers into null pointers");
+char RewriteUndefPtrs::ID = 0;
+static RegisterPass<RewriteUndefPtrs>
+    X("rewrite-undef-ptrs", "Transform undef pointers into null pointers");
 
-bool RemoveUndefPtrs::runOnFunction(Function &F) {
+bool RewriteUndefPtrs::runOnFunction(Function &F) {
   bool changed = false;
   for (inst_iterator I = inst_begin(F), E = inst_end(F); I != E; ++I) {
     for (auto OI = I->op_begin(), OE = I->op_end(); OI != OE; ++OI) {

--- a/lib/smack/SmackOptions.cpp
+++ b/lib/smack/SmackOptions.cpp
@@ -53,6 +53,10 @@ const llvm::cl::opt<bool> SmackOptions::RewriteBitwiseOps(
     llvm::cl::desc(
         "Provides models for bitwise operations in integer encoding."));
 
+const llvm::cl::opt<bool> SmackOptions::RewriteUndefPtrs(
+    "rewrite-undef-ptrs",
+    llvm::cl::desc("Rewrites pointers to undef values to null pointers."));
+
 const llvm::cl::opt<bool> SmackOptions::NoMemoryRegionSplitting(
     "no-memory-splitting",
     llvm::cl::desc("Disable splitting memory into regions."));

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -513,7 +513,6 @@ def arguments():
         help='''optionally rewrite pointers to undef values to null
                 pointers''')
 
-
     verifier_group = parser.add_argument_group('verifier options')
 
     verifier_group.add_argument(

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -506,6 +506,14 @@ def arguments():
         default=False,
         help='enable support for string')
 
+    translate_group.add_argument(
+        '--rewrite-undef-pointers',
+        action="store_true",
+        default=False,
+        help='''optionally rewrite pointers to undef values to null
+                pointers''')
+
+
     verifier_group = parser.add_argument_group('verifier options')
 
     verifier_group.add_argument(
@@ -738,6 +746,8 @@ def llvm_to_bpl(args):
         cmd += ['-float']
     if args.modular:
         cmd += ['-modular']
+    if args.rewrite_undef_pointers:
+        cmd += ['-rewrite-undef-ptrs']
     try_command(cmd, console=True)
     annotate_bpl(args)
     memsafety_subproperty_selection(args)

--- a/tools/llvm2bpl/llvm2bpl.cpp
+++ b/tools/llvm2bpl/llvm2bpl.cpp
@@ -37,6 +37,7 @@
 #include "smack/Naming.h"
 #include "smack/NormalizeLoops.h"
 #include "smack/RemoveDeadDefs.h"
+#include "smack/RemoveUndefPtrs.h"
 #include "smack/RewriteBitwiseOps.h"
 #include "smack/RustFixes.h"
 #include "smack/SimplifyLibCalls.h"
@@ -164,7 +165,6 @@ int main(int argc, char **argv) {
 
   // This runs before DSA because some Rust functions cause problems.
   pass_manager.add(new smack::RustFixes);
-
   if (!Modular) {
     auto PreserveKeyGlobals = [=](const llvm::GlobalValue &GV) {
       std::string name = GV.getName();
@@ -207,8 +207,10 @@ int main(int argc, char **argv) {
   }
   pass_manager.add(new llvm::MergeArrayGEP());
   // pass_manager.add(new smack::SimplifyLibCalls());
+  pass_manager.add(new smack::RemoveUndefPtrs());
   pass_manager.add(new llvm::Devirtualize());
   pass_manager.add(new smack::SplitAggregateValue());
+  pass_manager.add(new smack::RemoveUndefPtrs());
 
   if (smack::SmackOptions::MemorySafety) {
     pass_manager.add(new smack::MemorySafetyChecker());


### PR DESCRIPTION
This adds a pass which converts certain pointers to `undef` values into pointers to `null`. This is meant to move the program into a more defined state for alias analysis. Because this pass changes semantics, it is locked behind the option `--rewrite-undef-pointers` in order to opt in to this transformation.

This pass builds off of #686 because it includes optimizations relevant to verification of linked Rust programs.