### PR TITLE
Made casts from llvm::StringRef to std::string explicit

### DIFF
--- a/include/smack/Naming.h
+++ b/include/smack/Naming.h
@@ -5,6 +5,7 @@
 #ifndef NAMING_H
 #define NAMING_H
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/IR/Value.h"
 #include "llvm/Support/Regex.h"
 #include <map>
@@ -116,9 +117,9 @@ public:
   static std::string getIntWrapFunc(bool isUnsigned);
 
   static bool isBplKeyword(std::string s);
-  static bool isSmackName(std::string s);
+  static bool isSmackName(llvm::StringRef s);
   static bool isSmackGeneratedName(std::string s);
-  static bool isRustPanic(const std::string &s);
+  static bool isRustPanic(llvm::StringRef s);
   static std::string escape(std::string s);
 };
 } // namespace smack

--- a/include/smack/SmackOptions.h
+++ b/include/smack/SmackOptions.h
@@ -36,7 +36,7 @@ public:
   static const llvm::cl::opt<bool> AddTiming;
   static const llvm::cl::opt<bool> WrappedIntegerEncoding;
 
-  static bool isEntryPoint(std::string);
+  static bool isEntryPoint(llvm::StringRef);
 };
 } // namespace smack
 

--- a/lib/smack/AddTiming.cpp
+++ b/lib/smack/AddTiming.cpp
@@ -52,8 +52,7 @@ const std::string AddTiming::INT_TIMING_COST_METADATA =
 const std::string AddTiming::INSTRUCTION_NAME_METADATA =
     "smack.LLVMInstructionName";
 
-static bool begins_with(const std::string &possible_prefix,
-                        const std::string &the_string) {
+static bool begins_with(StringRef possible_prefix, StringRef the_string) {
   return (0 == the_string.find(possible_prefix));
 }
 

--- a/lib/smack/Debug.cpp
+++ b/lib/smack/Debug.cpp
@@ -55,7 +55,7 @@ struct DebugOnlyOpt {
     SmallVector<StringRef, 8> dbgTypes;
     StringRef(Val).split(dbgTypes, ',', -1, false);
     for (auto dbgType : dbgTypes)
-      CurrentDebugType->push_back(dbgType);
+      CurrentDebugType->push_back(dbgType.str());
   }
 };
 } // namespace

--- a/lib/smack/IntegerOverflowChecker.cpp
+++ b/lib/smack/IntegerOverflowChecker.cpp
@@ -127,10 +127,10 @@ bool IntegerOverflowChecker::runOnModule(Module &m) {
       if (auto ci = dyn_cast<CallInst>(&*I)) {
         Function *f = ci->getCalledFunction();
         if (f && f->hasName()) {
-          std::string fn = f->getName();
+          auto fn = f->getName();
           if (fn.find("__ubsan_handle_shift_out_of_bounds") !=
-                  std::string::npos ||
-              fn.find("__ubsan_handle_divrem_overflow") != std::string::npos) {
+                  StringRef::npos ||
+              fn.find("__ubsan_handle_divrem_overflow") != StringRef::npos) {
             // If the call to __ubsan_handle_* is reachable,
             // then an overflow is possible.
             if (SmackOptions::IntegerOverflow) {
@@ -144,7 +144,7 @@ bool IntegerOverflowChecker::runOnModule(Module &m) {
             }
           }
           SmallVector<StringRef, 4> info;
-          if (OVERFLOW_INTRINSICS.match(f->getName(), &info)) {
+          if (OVERFLOW_INTRINSICS.match(fn, &info)) {
             /*
              * If ei is an ExtractValueInst whose value flows from an LLVM
              * checked value intrinsic f, then we do the following:
@@ -158,12 +158,13 @@ bool IntegerOverflowChecker::runOnModule(Module &m) {
              * - Finally, an assumption about the value of the flag is created
              *   to block erroneous checking of paths after the overflow check.
              */
-            SDEBUG(errs() << "Processing intrinsic: " << f->getName().str()
-                          << "\n");
+            SDEBUG(errs() << "Processing intrinsic: " << fn << "\n");
             assert(info.size() == 4 && "Must capture three matched strings.");
             bool isSigned = (info[1] == "s");
-            std::string op = info[2];
-            int bits = std::stoi(info[3]);
+            std::string op = info[2].str();
+            unsigned bits = 0;
+            auto res = info[3].getAsInteger(10, bits);
+            assert(!res && "Invalid bit widths.");
             Value *eo1 =
                 extendBitWidth(ci->getArgOperand(0), bits, isSigned, ci);
             Value *eo2 =

--- a/lib/smack/Naming.cpp
+++ b/lib/smack/Naming.cpp
@@ -161,13 +161,13 @@ Regex Naming::SMACK_NAME(".*__SMACK_.*");
 
 bool Naming::isBplKeyword(std::string s) { return BPL_KW.match(s); }
 
-bool Naming::isSmackName(std::string n) { return SMACK_NAME.match(n); }
+bool Naming::isSmackName(llvm::StringRef n) { return SMACK_NAME.match(n); }
 
 bool Naming::isSmackGeneratedName(std::string n) {
   return n.size() > 0 && n[0] == '$';
 }
 
-bool Naming::isRustPanic(const std::string &name) {
+bool Naming::isRustPanic(llvm::StringRef name) {
   for (const auto &panic : Naming::RUST_PANICS) {
     // We are interested in exact functional matches.
     // Rust mangled names include a 17 byte hash at the end.

--- a/lib/smack/RemoveDeadDefs.cpp
+++ b/lib/smack/RemoveDeadDefs.cpp
@@ -23,15 +23,15 @@ bool RemoveDeadDefs::runOnModule(Module &M) {
   do {
     dead.clear();
     for (Function &F : M) {
-      std::string name = F.getName();
+      auto name = F.getName();
 
       if (!(F.isDefTriviallyDead() || F.getNumUses() == 0))
         continue;
 
-      if (name.find("__SMACK_") != std::string::npos)
+      if (name.find("__SMACK_") != StringRef::npos)
         continue;
 
-      if (name.find("__VERIFIER_assume") != std::string::npos)
+      if (name.find("__VERIFIER_assume") != StringRef::npos)
         continue;
 
       if (SmackOptions::isEntryPoint(name))

--- a/lib/smack/RustFixes.cpp
+++ b/lib/smack/RustFixes.cpp
@@ -37,8 +37,8 @@ bool fixEntry(Function &main) {
   for (inst_iterator I = inst_begin(main), E = inst_end(main); I != E; ++I) {
     if (auto ci = dyn_cast<CallInst>(&*I)) {
       if (Function *f = ci->getCalledFunction()) {
-        std::string name = f->hasName() ? f->getName() : "";
-        if (name.find(Naming::RUST_ENTRY) != std::string::npos) {
+        StringRef name = f->hasName() ? f->getName() : "";
+        if (name.find(Naming::RUST_ENTRY) != StringRef::npos) {
           // Get real Rust main
           auto castExpr = ci->getArgOperand(0);
           auto mainFunction = cast<Function>(castExpr);

--- a/lib/smack/SmackOptions.cpp
+++ b/lib/smack/SmackOptions.cpp
@@ -91,7 +91,7 @@ const llvm::cl::opt<bool> SmackOptions::WrappedIntegerEncoding(
     llvm::cl::desc(
         "Enable wrapped integer arithmetic and signedness-aware comparison"));
 
-bool SmackOptions::isEntryPoint(std::string name) {
+bool SmackOptions::isEntryPoint(llvm::StringRef name) {
   for (auto EP : EntryPoints)
     if (name == EP)
       return true;


### PR DESCRIPTION
This commit also replaces some usages of std::string with
llvm::StringRef.

Partially fixes #691