### PR TITLE
Add Cargo examples to regressions

### DIFF
--- a/.github/workflows/smack-ci.yaml
+++ b/.github/workflows/smack-ci.yaml
@@ -33,6 +33,7 @@ jobs:
             "--exhaustive --folder=rust/recursion --languages=rust",
             "--exhaustive --folder=rust/structures --languages=rust",
             "--exhaustive --folder=rust/vector --languages=rust",
+            "--exhaustive --folder=rust/cargo/** --languages=cargo --threads=1",
             "--exhaustive --folder=llvm --languages=llvm-ir"
           ]
     steps:

--- a/test/regtest.py
+++ b/test/regtest.py
@@ -19,6 +19,7 @@ OVERRIDE_FIELDS = ['verifiers', 'memory', 'time-limit', 'memory-limit', 'skip']
 APPEND_FIELDS = ['flags', 'checkbpl', 'checkout']
 
 LANGUAGES = {'c': {'*.c'},
+             'cargo': {'Cargo.toml'},
              'cplusplus': {'*.cpp'},
              'rust': {'*.rs'},
              'llvm-ir': {"*.ll"}}

--- a/test/rust/cargo/num-crate-test-fail/Cargo.toml
+++ b/test/rust/cargo/num-crate-test-fail/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = ["smackers"]
 edition = "2018"
 
+# @expect error
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/test/rust/cargo/num-crate-test/Cargo.toml
+++ b/test/rust/cargo/num-crate-test/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = ["smackers"]
 edition = "2018"
 
+# @expect verified
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
I had to run them one by one otherwise concurrency issues of Cargo will be triggered, which leads to incorrect results.