### PR TITLE
Add an option to enable targeted checking of specific functions

### DIFF
--- a/.github/workflows/smack-ci.yaml
+++ b/.github/workflows/smack-ci.yaml
@@ -23,6 +23,7 @@ jobs:
             "--exhaustive --folder=c/pthread_extras",
             "--exhaustive --folder=c/strings",
             "--exhaustive --folder=c/special",
+            "--exhaustive --folder=c/targeted-checks",
             "--exhaustive --folder=rust/array --languages=rust",
             "--exhaustive --folder=rust/basic --languages=rust",
             "--exhaustive --folder=rust/box --languages=rust",
@@ -32,6 +33,7 @@ jobs:
             "--exhaustive --folder=rust/panic --languages=rust",
             "--exhaustive --folder=rust/recursion --languages=rust",
             "--exhaustive --folder=rust/structures --languages=rust",
+            "--exhaustive --folder=rust/targeted-checks",
             "--exhaustive --folder=rust/vector --languages=rust",
             "--exhaustive --folder=rust/cargo/** --languages=cargo --threads=1",
             "--exhaustive --folder=llvm --languages=llvm-ir"

--- a/include/smack/SmackOptions.h
+++ b/include/smack/SmackOptions.h
@@ -15,6 +15,7 @@ enum class LLVMAssumeType { none, use, check };
 class SmackOptions {
 public:
   static const llvm::cl::list<std::string> EntryPoints;
+  static const llvm::cl::list<std::string> CheckedFunctions;
 
   static const llvm::cl::opt<SmackWarnings::WarningLevel> WarningLevel;
   static const llvm::cl::opt<bool> ColoredWarnings;
@@ -37,6 +38,7 @@ public:
   static const llvm::cl::opt<bool> WrappedIntegerEncoding;
 
   static bool isEntryPoint(llvm::StringRef);
+  static bool shouldCheckFunction(llvm::StringRef);
 };
 } // namespace smack
 

--- a/lib/smack/IntegerOverflowChecker.cpp
+++ b/lib/smack/IntegerOverflowChecker.cpp
@@ -137,7 +137,8 @@ bool IntegerOverflowChecker::runOnModule(Module &m) {
               // Add check for UBSan left shift/signed division when needed
               ConstantInt *flag =
                   ConstantInt::getTrue(ci->getFunction()->getContext());
-              addCheck(co, flag, ci);
+              if (SmackOptions::shouldCheckFunction(F.getName()))
+                addCheck(co, flag, ci);
               addBlockingAssume(va, flag, ci);
               ci->replaceAllUsesWith(flag);
               instToErase.push_back(ci);
@@ -176,7 +177,8 @@ bool IntegerOverflowChecker::runOnModule(Module &m) {
                 INSTRUCTION_TABLE.at(op), eo1, eo2, "", ci);
             Value *r = createResult(ai, bits, &*I);
             BinaryOperator *flag = createFlag(ai, bits, isSigned, ci);
-            if (SmackOptions::IntegerOverflow)
+            if (SmackOptions::IntegerOverflow &&
+                SmackOptions::shouldCheckFunction(F.getName()))
               addCheck(co, flag, ci);
             for (auto U : ci->users()) {
               if (ExtractValueInst *ei = dyn_cast<ExtractValueInst>(U)) {

--- a/lib/smack/MemorySafetyChecker.cpp
+++ b/lib/smack/MemorySafetyChecker.cpp
@@ -55,7 +55,8 @@ void MemorySafetyChecker::insertMemoryAccessCheck(Value *addr, Value *size,
 }
 
 bool MemorySafetyChecker::runOnFunction(Function &F) {
-  if (Naming::isSmackName(F.getName()))
+  if (Naming::isSmackName(F.getName()) ||
+      !SmackOptions::shouldCheckFunction(F.getName()))
     return false;
 
   this->visit(F);

--- a/lib/smack/SmackOptions.cpp
+++ b/lib/smack/SmackOptions.cpp
@@ -4,6 +4,7 @@
 
 #include "smack/SmackOptions.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Regex.h"
 
 namespace smack {
 
@@ -104,8 +105,15 @@ bool SmackOptions::isEntryPoint(llvm::StringRef name) {
 }
 
 bool SmackOptions::shouldCheckFunction(llvm::StringRef name) {
-  return CheckedFunctions.size() == 0 || // If empty, check everything
-         std::find(CheckedFunctions.begin(), CheckedFunctions.end(), name) !=
-             CheckedFunctions.end();
+  if (CheckedFunctions.size() == 0) {
+    return false;
+  }
+  for (llvm::StringRef s : CheckedFunctions) {
+    llvm::SmallVector<llvm::StringRef, 10> matches;
+    if (llvm::Regex(s).match(name, &matches) && matches[0] == name) {
+      return true;
+    }
+  }
+  return false;
 }
 } // namespace smack

--- a/lib/smack/SmackOptions.cpp
+++ b/lib/smack/SmackOptions.cpp
@@ -12,6 +12,11 @@ const llvm::cl::list<std::string>
                               llvm::cl::desc("Entry point procedure names"),
                               llvm::cl::value_desc("PROCS"));
 
+const llvm::cl::list<std::string> SmackOptions::CheckedFunctions(
+    "checked-functions", llvm::cl::ZeroOrMore,
+    llvm::cl::desc("Functions in which to check properties"),
+    llvm::cl::value_desc("PROCS"));
+
 const llvm::cl::opt<SmackWarnings::WarningLevel> SmackOptions::WarningLevel(
     "warn-type", llvm::cl::desc("Enable certain type of warning messages."),
     llvm::cl::values(clEnumValN(SmackWarnings::WarningLevel::Silent, "silent",
@@ -96,5 +101,11 @@ bool SmackOptions::isEntryPoint(llvm::StringRef name) {
     if (name == EP)
       return true;
   return false;
+}
+
+bool SmackOptions::shouldCheckFunction(llvm::StringRef name) {
+  return CheckedFunctions.size() == 0 || // If empty, check everything
+         std::find(CheckedFunctions.begin(), CheckedFunctions.end(), name) !=
+             CheckedFunctions.end();
 }
 } // namespace smack

--- a/lib/smack/SmackOptions.cpp
+++ b/lib/smack/SmackOptions.cpp
@@ -106,7 +106,7 @@ bool SmackOptions::isEntryPoint(llvm::StringRef name) {
 
 bool SmackOptions::shouldCheckFunction(llvm::StringRef name) {
   if (CheckedFunctions.size() == 0) {
-    return false;
+    return true;
   }
   for (llvm::StringRef s : CheckedFunctions) {
     llvm::SmallVector<llvm::StringRef, 10> matches;

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -470,6 +470,13 @@ def arguments():
         help='specify top-level procedures [default: %(default)s]')
 
     translate_group.add_argument(
+        '--checked-functions',
+        metavar='PROC',
+        nargs='+',
+        default=[],
+        help='specify functions to do property checking [default: everything]')
+
+    translate_group.add_argument(
         '--check',
         metavar='PROPERTY',
         nargs='+',
@@ -702,6 +709,8 @@ def llvm_to_bpl(args):
     cmd += ['-source-loc-syms']
     for ep in args.entry_points:
         cmd += ['-entry-points', ep]
+    for cf in args.checked_functions:
+        cmd += ['-checked-functions', cf]
     if args.debug:
         cmd += ['-debug']
     if args.debug_only:

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -474,7 +474,10 @@ def arguments():
         metavar='PROC',
         nargs='+',
         default=[],
-        help='specify functions to do property checking [default: everything]')
+        help='''specify functions on which to do property checking.
+                These can be specified as extended regular expressions.
+                NOTE: a regular expression must match the entire
+                function name. [default: everything]''')
 
     translate_group.add_argument(
         '--check',

--- a/test/c/targeted-checks/targeted_assertion.c
+++ b/test/c/targeted-checks/targeted_assertion.c
@@ -1,0 +1,9 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @flag --checked-functions main
+// @expect verified
+
+void fun() { __VERIFIER_assert(__VERIFIER_nondet_int()); }
+
+int main() { fun(); }

--- a/test/c/targeted-checks/targeted_assertion_fail.c
+++ b/test/c/targeted-checks/targeted_assertion_fail.c
@@ -1,0 +1,9 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @flag --checked-functions main fun
+// @expect error
+
+void fun() { __VERIFIER_assert(__VERIFIER_nondet_int()); }
+
+int main() { fun(); }

--- a/test/c/targeted-checks/targeted_assume_checking.c
+++ b/test/c/targeted-checks/targeted_assume_checking.c
@@ -1,0 +1,11 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @flag --checked-functions main
+// @flag --llvm-assumes check
+// @flag --check none
+// @expect verified
+
+void fun() { __builtin_assume(__VERIFIER_nondet_int() == 0); }
+
+int main() { fun(); }

--- a/test/c/targeted-checks/targeted_assume_checking_fail.c
+++ b/test/c/targeted-checks/targeted_assume_checking_fail.c
@@ -1,0 +1,11 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @flag --checked-functions main fun
+// @flag --llvm-assumes check
+// @flag --check none
+// @expect verified
+
+void fun() { __builtin_assume(__VERIFIER_nondet_int() == 0); }
+
+int main() { fun(); }

--- a/test/c/targeted-checks/targeted_memory_safety.c
+++ b/test/c/targeted-checks/targeted_memory_safety.c
@@ -1,0 +1,22 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @flag --checked-functions main
+// @flag --check memory-safety
+// @expect verified
+
+struct BUF {
+  int *x;
+  size_t size;
+};
+
+int get_last(struct BUF b) {
+  // Access one past end of array
+  return b.x[b.size];
+}
+
+int main() {
+  int a[5] = {};
+  struct BUF x = {a, 5};
+  return get_last(x);
+}

--- a/test/c/targeted-checks/targeted_memory_safety_fail.c
+++ b/test/c/targeted-checks/targeted_memory_safety_fail.c
@@ -1,0 +1,22 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @flag --checked-functions main get_last
+// @flag --check memory-safety
+// @expect error
+
+struct BUF {
+  int *x;
+  size_t size;
+};
+
+int get_last(struct BUF b) {
+  // Access one past end of array
+  return b.x[b.size];
+}
+
+int main() {
+  int a[5] = {};
+  struct BUF x = {a, 5};
+  return get_last(x);
+}

--- a/test/c/targeted-checks/targeted_overflow_arithmetic.c
+++ b/test/c/targeted-checks/targeted_overflow_arithmetic.c
@@ -1,0 +1,14 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @flag --checked-functions main
+// @flag --check integer-overflow
+// @expect verified
+
+int compute(int a, int b) { return a + b; }
+
+int main() {
+  int a = __VERIFIER_nondet_int();
+  int b = __VERIFIER_nondet_int();
+  return compute(a, b);
+}

--- a/test/c/targeted-checks/targeted_overflow_arithmetic_fail.c
+++ b/test/c/targeted-checks/targeted_overflow_arithmetic_fail.c
@@ -1,0 +1,14 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @flag --checked-functions main compute
+// @flag --check integer-overflow
+// @expect error
+
+int compute(int a, int b) { return a + b; }
+
+int main() {
+  int a = __VERIFIER_nondet_int();
+  int b = __VERIFIER_nondet_int();
+  return compute(a, b);
+}

--- a/test/c/targeted-checks/targeted_overflow_shift.c
+++ b/test/c/targeted-checks/targeted_overflow_shift.c
@@ -1,0 +1,14 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @flag --checked-functions main
+// @flag --check integer-overflow
+// @expect verified
+
+int compute(int a, int b) { return a << b; }
+
+int main() {
+  int a = __VERIFIER_nondet_int();
+  int b = __VERIFIER_nondet_int();
+  return compute(a, b);
+}

--- a/test/c/targeted-checks/targeted_overflow_shift_fail.c
+++ b/test/c/targeted-checks/targeted_overflow_shift_fail.c
@@ -1,0 +1,14 @@
+#include "smack.h"
+#include <stdlib.h>
+
+// @flag --checked-functions main compute
+// @flag --check integer-overflow
+// @expect error
+
+int compute(int a, int b) { return a << b; }
+
+int main() {
+  int a = __VERIFIER_nondet_int();
+  int b = __VERIFIER_nondet_int();
+  return compute(a, b);
+}

--- a/test/c/targeted-checks/test-match.c
+++ b/test/c/targeted-checks/test-match.c
@@ -1,0 +1,13 @@
+#include "smack.h"
+
+// @flag --checked-functions should_match1
+// @expect verified
+
+int should_match1() { assert(1); }
+
+int should_match12() { assert(0); }
+
+int main() {
+  should_match1();
+  should_match12();
+}

--- a/test/c/targeted-checks/test-match_fail1.c
+++ b/test/c/targeted-checks/test-match_fail1.c
@@ -1,0 +1,13 @@
+#include "smack.h"
+
+// @flag --checked-functions should_match12
+// @expect error
+
+int should_match1() { assert(1); }
+
+int should_match12() { assert(0); }
+
+int main() {
+  should_match1();
+  should_match12();
+}

--- a/test/c/targeted-checks/test-match_fail2.c
+++ b/test/c/targeted-checks/test-match_fail2.c
@@ -1,0 +1,13 @@
+#include "smack.h"
+
+// @flag --checked-functions should_match1.*
+// @expect error
+
+int should_match1() { assert(1); }
+
+int should_match12() { assert(0); }
+
+int main() {
+  should_match1();
+  should_match12();
+}

--- a/test/c/targeted-checks/test-match_fail3.c
+++ b/test/c/targeted-checks/test-match_fail3.c
@@ -1,0 +1,13 @@
+#include "smack.h"
+
+// @flag --checked-functions should_match.*
+// @expect error
+
+int should_match1() { assert(1); }
+
+int should_match12() { assert(0); }
+
+int main() {
+  should_match1();
+  should_match12();
+}

--- a/test/rust/targeted-checks/targeted_panic.rs
+++ b/test/rust/targeted-checks/targeted_panic.rs
@@ -1,0 +1,16 @@
+#[macro_use]
+extern crate smack;
+use smack::*;
+
+// @flag --checked-functions main
+// @flag --check rust-panics
+// @expect verified
+
+#[no_mangle]
+fn dont_call_me() {
+    panic!();
+}
+
+fn main() {
+    dont_call_me();
+}

--- a/test/rust/targeted-checks/targeted_panic2.rs
+++ b/test/rust/targeted-checks/targeted_panic2.rs
@@ -1,0 +1,15 @@
+#[macro_use]
+extern crate smack;
+use smack::*;
+
+// @flag --checked-functions _ZN20targeted_panic_fail212dont_call_me17h.{16}
+// @flag --check rust-panics
+// @expect verified
+
+fn dont_call_me() {
+    panic!();
+}
+
+fn main() {
+    dont_call_me();
+}

--- a/test/rust/targeted-checks/targeted_panic2_fail.rs
+++ b/test/rust/targeted-checks/targeted_panic2_fail.rs
@@ -1,0 +1,15 @@
+#[macro_use]
+extern crate smack;
+use smack::*;
+
+// @flag --checked-functions _ZN20targeted_panic_fail212dont_call_me17h.{17}
+// @flag --check rust-panics
+// @expect error
+
+fn dont_call_me() {
+    panic!();
+}
+
+fn main() {
+    dont_call_me();
+}

--- a/test/rust/targeted-checks/targeted_panic_fail.rs
+++ b/test/rust/targeted-checks/targeted_panic_fail.rs
@@ -1,0 +1,16 @@
+#[macro_use]
+extern crate smack;
+use smack::*;
+
+// @flag --checked-functions dont_call_me
+// @flag --check rust-panics
+// @expect error
+
+#[no_mangle]
+fn dont_call_me() {
+    panic!();
+}
+
+fn main() {
+    dont_call_me();
+}


### PR DESCRIPTION
This adds the ability to selectively check certain functions in a program, specifically:
* This adds the option `--checked-functions' which is a list of functions
  on which to do checking
* Not specifying this option enables all checks in every function
This partially addresses #713 