### PR TITLE
Generate precise error type when Boogie is used

### DIFF
--- a/share/smack/svcomp/utils.py
+++ b/share/smack/svcomp/utils.py
@@ -104,7 +104,7 @@ def verify_bpl_svcomp(args):
   corral_command += ["/trackAllVars"]
 
   verifier_output = smack.top.try_command(corral_command, timeout=time_limit)
-  result = smack.top.verification_result(verifier_output)
+  result = smack.top.verification_result(verifier_output, 'corral')
 
   if result in VResult.ERROR: #normal inlining
     heurTrace += "Found a bug during normal inlining.\n"

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -856,13 +856,13 @@ def verification_result(verifier_output, verifier):
         attr = None
         attr_pat = r'assert {:(.+)}'
 
-        if args.verifier == 'corral':
+        if verifier == 'corral':
             corral_af_msg = re.search(r'ASSERTION FAILS %s' % attr_pat,
                                       verifier_output)
             if corral_af_msg:
                 attr = corral_af_msg.group(1)
 
-        elif args.verifier == 'boogie':
+        elif verifier == 'boogie':
             boogie_af_msg = re.search(
                 r'([\w#$~%.\/-]+)\((\d+),\d+\): '
                 r'Error: This assertion might not hold', verifier_output)


### PR DESCRIPTION
Previously, SMACK doesn't report the error type such as ``invalid pointer
dereference'' when Boogie is used. This commit fixes it. Furthermore, the
original error type generation for Corral is also improved.