### PR TITLE
Make llvm-dis use LLVM short version in top.py

### DIFF
--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -2,9 +2,9 @@ import os
 import sys
 import re
 import json
-from .utils import temporary_file, try_command, temporary_directory
+from .utils import temporary_file, try_command, temporary_directory,\
+    llvm_exact_bin
 from .versions import RUST_VERSION
-from .versions import LLVM_SHORT_VERSION
 
 # Needed for cargo operations
 try:
@@ -84,10 +84,6 @@ def smack_headers(args):
 
 def smack_lib():
     return os.path.join(smack_root(), 'share', 'smack', 'lib')
-
-
-def llvm_exact_bin(name):
-    return name + '-' + LLVM_SHORT_VERSION
 
 
 def default_clang_compile_command(args, lib=False):

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -8,7 +8,8 @@ import signal
 import functools
 from enum import Flag, auto
 from .svcomp.utils import verify_bpl_svcomp
-from .utils import temporary_file, try_command, remove_temp_files
+from .utils import temporary_file, try_command, remove_temp_files,\
+    llvm_exact_bin
 from .replay import replay_error_trace
 from .frontend import link_bc_files, frontends, languages, extra_libs
 from .errtrace import error_trace, smackdOutput
@@ -652,7 +653,7 @@ def target_selection(args):
                     os.path.basename(src))[0],
                 '.ll',
                 args)
-            try_command(['llvm-dis', '-o', ll, src])
+            try_command([llvm_exact_bin('llvm-dis'), '-o', ll, src])
             src = ll
         if os.path.splitext(src)[1] == '.ll':
             with open(src, 'r') as f:

--- a/share/smack/utils.py
+++ b/share/smack/utils.py
@@ -6,6 +6,7 @@ import subprocess
 import signal
 from threading import Timer
 from . import top
+from .versions import LLVM_SHORT_VERSION
 
 temporary_files = []
 
@@ -104,3 +105,7 @@ def try_command(cmd, cwd=None, console=False, timeout=None, env=None):
         if filelog:
             with open(temporary_file(cmd[0], '.log', args), 'w') as f:
                 f.write(output)
+
+
+def llvm_exact_bin(name):
+    return name + '-' + LLVM_SHORT_VERSION


### PR DESCRIPTION
This PR makes our usage of LLVM's command line utilities more consistent by making `llvm-dis` use the Smack installed version of the LLVM package.