### PR TITLE
Remove calls to Rust's panic functions

### DIFF
--- a/include/smack/Naming.h
+++ b/include/smack/Naming.h
@@ -97,6 +97,7 @@ public:
   static const std::string RUST_LANG_START_INTERNAL;
   static const std::vector<std::string> RUST_PANICS;
   static const std::string RUST_PANIC_ANNOTATION;
+  static const std::string RUST_PANIC_MARKER;
 
   static const std::string INT_WRAP_SIGNED_FUNCTION;
   static const std::string INT_WRAP_UNSIGNED_FUNCTION;

--- a/lib/smack/Naming.cpp
+++ b/lib/smack/Naming.cpp
@@ -71,6 +71,8 @@ const std::vector<std::string> Naming::RUST_PANICS = {
 
 const std::string Naming::RUST_PANIC_ANNOTATION = "rust_panic";
 
+const std::string Naming::RUST_PANIC_MARKER = "__SMACK_RUST_PANIC_MARKER";
+
 const std::string Naming::BLOCK_LBL = "$bb";
 const std::string Naming::RET_VAR = "$r";
 const std::string Naming::EXN_VAR = "$exn";

--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -648,7 +648,7 @@ void SmackInstGenerator::visitCallInst(llvm::CallInst &ci) {
 
   StringRef name = f->hasName() ? f->getName() : "";
 
-  if (SmackOptions::RustPanics && Naming::isRustPanic(name) &&
+  if (SmackOptions::RustPanics && name == Naming::RUST_PANIC_MARKER &&
       SmackOptions::shouldCheckFunction(
           ci.getParent()->getParent()->getName())) {
     // Convert Rust's panic functions into assertion violations


### PR DESCRIPTION
This removes the calls to panic functions called by Rust programs. Removing the calls enables dead code elimination to remove the arguments flowing into the panic function call.