### PR TITLE
Added unroll folder to regressions

### DIFF
--- a/.github/workflows/smack-ci.yaml
+++ b/.github/workflows/smack-ci.yaml
@@ -24,6 +24,7 @@ jobs:
             "--exhaustive --folder=c/strings",
             "--exhaustive --folder=c/special",
             "--exhaustive --folder=c/targeted-checks",
+            "--exhaustive --folder=c/unroll",
             "--exhaustive --folder=rust/array --languages=rust",
             "--exhaustive --folder=rust/basic --languages=rust",
             "--exhaustive --folder=rust/box --languages=rust",

--- a/test/c/unroll/config.yml
+++ b/test/c/unroll/config.yml
@@ -1,2 +1,3 @@
 skip: false
+verifiers: [corral]
 flags: [--fail-on-loop-exit]


### PR DESCRIPTION
Also, we should only use Corral on the regressions in the unroll folder.
The reason is that Boogie's unrolling of nested loops is not intuitive.
For example, nested loops of 5 iterations each need 25 or so unrolls
in Boogie to be fully unrolled.