### PR TITLE
update file reading to yaml.safe_load

### DIFF
--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -1078,7 +1078,7 @@ def thread_verify_bpl(args, args_to_add):
 
 def verify_bpl_portfolio(args):
 
-    portfolio_config = yaml.load(open(args.portfolio_config, 'r'))
+    portfolio_config = yaml.safe_load(open(args.portfolio_config, 'r'))
     p = multiprocessing.Pool()
     results = {}  # map of process -> thread name
 


### PR DESCRIPTION
Now use safe_load() instead of load() for reading yaml files as is consistent with PyYaml 6.0