### PR TITLE
Removed unnecessary compiler selection in `build.rs`

### DIFF
--- a/share/smack/lib/smack/build.rs
+++ b/share/smack/lib/smack/build.rs
@@ -5,7 +5,6 @@ fn main() {
         .file("src/smack-rust.c")
         .define("CARGO_BUILD", None)
         .include("src")
-        .compiler("clang")
         .compile("libsmack.a");
     println!("cargo:rerun-if-changed=src/smack-rust.c");
 }


### PR DESCRIPTION
It shouldn't matter what the C compiler that the `cc` crate uses. So, I removed this function call such that we don't see cargo build failure in an environment such as our Docker image, where `clang` is not in the path.