### PR TITLE
Fix svcomp assert

### DIFF
--- a/share/smack/svcomp/utils.py
+++ b/share/smack/svcomp/utils.py
@@ -69,24 +69,12 @@ def force_timeout():
   sys.stdout.flush()
   time.sleep(1000)
 
-def inject_assert_false(args):
-  with open(args.bpl_file, 'r') as bf:
-    content = bf.read()
-  content = content.replace('call reach_error();', 'assert false; call reach_error();')
-  with open(args.bpl_file, 'w') as bf:
-    bf.write(content)
-
 def verify_bpl_svcomp(args):
   """Verify the Boogie source file using SVCOMP-tuned heuristics."""
   heurTrace = "\n\nHeuristics Info:\n"
 
   from smack.top import VProperty
   from smack.top import VResult
-
-  if not (VProperty.MEMORY_SAFETY in args.check
-          or VProperty.MEMLEAK in args.check
-          or VProperty.INTEGER_OVERFLOW in args.check):
-    inject_assert_false(args)
 
   # Setting good loop unroll bound based on benchmark class
   loopUnrollBar = 13

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -848,15 +848,15 @@ def replace_reach_error(args):
     if args.language != 'svcomp':
         return
 
-    if VProperty.MEMORY_SAFETY in args.check or
-       VProperty.MEMLEAK in args.check or
-       VProperty.INTEGER_OVERFLOW in args.check:
+    if (VProperty.MEMORY_SAFETY in args.check or
+            VProperty.MEMLEAK in args.check or
+            VProperty.INTEGER_OVERFLOW in args.check):
         return
 
     with open(args.bpl_file, 'r') as bf:
         content = bf.read()
     content = content.replace('call reach_error();',
-        'assert false; call reach_error();')
+                              'assert false; call reach_error();')
     with open(args.bpl_file, 'w') as bf:
         bf.write(content)
 

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -843,18 +843,20 @@ def memsafety_subproperty_selection(args):
 
 
 def replace_reach_error(args):
-    """Replaces a call to reach_error in SVCOMP benchmarks with assert false."""
+    """Replaces calls to reach_error in SVCOMP benchmarks with assert false."""
 
     if args.language != 'svcomp':
         return
 
-    if (VProperty.MEMORY_SAFETY in args.check or VProperty.MEMLEAK in args.check
-        or VProperty.INTEGER_OVERFLOW in args.check):
+    if VProperty.MEMORY_SAFETY in args.check or
+       VProperty.MEMLEAK in args.check or
+       VProperty.INTEGER_OVERFLOW in args.check:
         return
 
     with open(args.bpl_file, 'r') as bf:
         content = bf.read()
-    content = content.replace('call reach_error();', 'assert false; call reach_error();')
+    content = content.replace('call reach_error();',
+        'assert false; call reach_error();')
     with open(args.bpl_file, 'w') as bf:
         bf.write(content)
 


### PR DESCRIPTION
Moving dealing with SVCOMP asserts into the main flow so that we can experiment with SVCOMP benchmarks without having to set verifier to SVCOMP.