### PR TITLE
Set Rust's panic behavior as aborting instead of unwinding

### DIFF
--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -356,7 +356,9 @@ def default_rust_compile_args(args):
             '--cfg',
             'verifier="smack"',
             '-C',
-            'passes=name-anon-globals']
+            'passes=name-anon-globals',
+            '-C',
+            'panic=abort']
 
 
 def default_rust_compile_command(args):


### PR DESCRIPTION
Stack unwinding logic is very complicated and even though the
functions associated with it are not called, they stay in the
program. This commit lets Rust programs to abort when panics
occur, which produces much simpler programs.