### PR TITLE
Fixes to run SMACK on modern macOS

### DIFF
--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -337,7 +337,7 @@ def cargo_frontend(input_file, args):
     target_pattern = target_name + r'(-[a-f0-9]{16})?\.bc'
     r = re.compile(target_pattern)
     bcs = list(filter(r.match, entries))
-    assert(len(bcs) == 1)
+    assert (len(bcs) == 1)
 
     return bcbase + bcs[0]
 

--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -334,8 +334,8 @@ def cargo_frontend(input_file, args):
 
     # Matches either target_name.bc or target_name-0123456789abcdef.bc
     # depending on platform
-    target_pat = target_name + r'(-[a-f0-9]{16})?\.bc'
-    r = re.compile(target_pat)
+    target_pattern = target_name + r'(-[a-f0-9]{16})?\.bc'
+    r = re.compile(target_pattern)
     bcs = list(filter(r.match, entries))
     assert(len(bcs) == 1)
 

--- a/share/smack/frontend.py
+++ b/share/smack/frontend.py
@@ -332,17 +332,14 @@ def cargo_frontend(input_file, args):
     entries = os.listdir(bcbase)
     bcs = []
 
-    for entry in entries:
-        if entry.startswith(target_name + '-') and entry.endswith('.bc'):
-            bcs.append(bcbase + entry)
+    # Matches either target_name.bc or target_name-0123456789abcdef.bc
+    # depending on platform
+    target_pat = target_name + r'(-[a-f0-9]{16})?\.bc'
+    r = re.compile(target_pat)
+    bcs = list(filter(r.match, entries))
+    assert(len(bcs) == 1)
 
-    bc_file = temporary_file(
-        os.path.splitext(
-            os.path.basename(input_file))[0],
-        '.bc',
-        args)
-    try_command([llvm_exact_bin('llvm-link')] + bcs + ['-o', bc_file])
-    return bc_file
+    return bcbase + bcs[0]
 
 
 def default_rust_compile_args(args):

--- a/test/regtest.py
+++ b/test/regtest.py
@@ -14,6 +14,7 @@ import glob
 import time
 import sys
 import shlex
+import pathlib
 
 OVERRIDE_FIELDS = ['verifiers', 'memory', 'time-limit', 'memory-limit', 'skip']
 APPEND_FIELDS = ['flags', 'checkbpl', 'checkout']
@@ -70,11 +71,12 @@ def merge(metadata, yamldata):
 def metadata(file):
     m = {}
     prefix = []
+    path = pathlib.Path(file)
 
-    for d in path.dirname(file).split('/'):
+    for d in path.parent.parts:
         prefix += [d]
-        yaml_file = path.join(*(prefix + ['config.yml']))
-        if path.isfile(yaml_file):
+        yaml_file = pathlib.Path(*(prefix + ['config.yml']))
+        if yaml_file.is_file():
             with open(yaml_file, "r") as f:
                 data = yaml.safe_load(f)
                 merge(m, data)

--- a/test/regtest.py
+++ b/test/regtest.py
@@ -73,7 +73,7 @@ def metadata(file):
     prefix = []
     path = pathlib.Path(file)
 
-    for d in path.parent.parts:
+    for d in ('./',) + path.parent.parts:
         prefix += [d]
         yaml_file = pathlib.Path(*(prefix + ['config.yml']))
         if yaml_file.is_file():


### PR DESCRIPTION
This PR addresses the following: 
* Improves path manipulation in `regtest.py` to be more compatible with macOS (based on work by @shaobo-he)
* Extends the expected name for `bc` files generated by `cargo` to support an optional 16 digit hash

Co-authored-by: @shaobo-he 