### PR TITLE
Add Ubuntu 24.04 (noble) support

### DIFF
--- a/.github/workflows/smack-ci.yaml
+++ b/.github/workflows/smack-ci.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   check-regressions:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         regtest_env:
@@ -59,7 +59,7 @@ jobs:
         run: ./bin/build.sh
 
   build-and-push-docker:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: check-regressions
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 MAINTAINER Shaobo He <polarishehn@gmail.com>
 
 ENV SMACKDIR /home/user/smack

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -200,7 +200,7 @@ linux-opensuse*)
   DEPENDENCIES+=" ncurses-devel"
   ;;
 
-linux-@(ubuntu|neon)-@(16|18|20|22)*)
+linux-@(ubuntu|neon)-@(16|18|20|22|24)*)
   if [ ${INSTALL_LLVM} -eq 1 ] ; then
     DEPENDENCIES+=" clang-${LLVM_SHORT_VERSION} llvm-${LLVM_SHORT_VERSION}-dev"
   fi
@@ -248,7 +248,7 @@ if [ ${INSTALL_DEPENDENCIES} -eq 1 ] ; then
     sudo zypper --non-interactive install ${DEPENDENCIES}
     ;;
 
-  linux-@(ubuntu|neon)-@(1[68]|20|22)*)
+  linux-@(ubuntu|neon)-@(1[68]|20|22|24)*)
     RELEASE_VERSION=$(get-platform-trim "$(lsb_release -r)" | awk -F: '{print $2;}')
     case "$RELEASE_VERSION" in
     16*)
@@ -263,6 +263,9 @@ if [ ${INSTALL_DEPENDENCIES} -eq 1 ] ; then
     22*)
       UBUNTU_CODENAME="jammy"
       ;;
+    24*)
+      UBUNTU_CODENAME="noble"
+      ;;
     *)
       puts "Release ${RELEASE_VERSION} for ${distro} not supported. Dependencies must be installed manually."
       exit 1
@@ -274,13 +277,25 @@ if [ ${INSTALL_DEPENDENCIES} -eq 1 ] ; then
     fi
 
     # Adding LLVM repository
-    if [ ${INSTALL_LLVM} -eq 1 ] ; then
+    # Ubuntu 24.04 (noble) ships the pinned Clang/LLVM version in its own
+    # (universe) repositories, and apt.llvm.org has no llvm-toolchain-noble feed
+    # for it, so on 24.04 the LLVM packages are installed directly from the Ubuntu
+    # archive instead of adding an apt.llvm.org repository (which also avoids the
+    # removed apt-key on noble).
+    if [ ${INSTALL_LLVM} -eq 1 ] && [[ "$RELEASE_VERSION" != 24* ]] ; then
       ${WGET} -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
       sudo add-apt-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-${LLVM_SHORT_VERSION} main"
     fi
 
-    # Adding .NET repository (skip for 22.04+ as it provides .NET 6 natively)
-    if [[ "$RELEASE_VERSION" != 22* ]]; then
+    # Adding .NET repository for dotnet-sdk-6.0 (required by Boogie and Corral):
+    # - 20.04 and older: use Microsoft's package feed
+    # - 22.04: .NET 6 is available in the default Ubuntu repositories
+    # - 24.04: .NET 6 is neither in the Ubuntu archive nor Microsoft's feed
+    #   (Microsoft stopped publishing to packages.microsoft.com for 24.04), so
+    #   use Canonical's dotnet backports PPA
+    if [[ "$RELEASE_VERSION" == 24* ]]; then
+      sudo add-apt-repository -y ppa:dotnet/backports
+    elif [[ "$RELEASE_VERSION" != 22* ]]; then
       ${WGET} -q https://packages.microsoft.com/config/ubuntu/${RELEASE_VERSION}/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
       sudo DEBIAN_FRONTEND=noninteractive dpkg -i --force-confdef --force-confold packages-microsoft-prod.deb
       rm -f packages-microsoft-prod.deb

--- a/share/smack/svcomp/toSVCOMPformat.py
+++ b/share/smack/svcomp/toSVCOMPformat.py
@@ -154,7 +154,7 @@ def smackJsonToXmlGraph(strJsonOutput, args, hasBug, status):
 
       lastNode = start
       lastEdge = None
-      pat = re.compile(".*/smack/lib/.+\.[c|h]$")
+      pat = re.compile(r".*/smack/lib/.+\.[c|h]$")
       prevLineNo = -1
       prevColNo = -1
       callStack = [('main', '0')]

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -492,10 +492,10 @@ def arguments():
         '--check',
         metavar='PROPERTY',
         nargs='+',
-        # Use __members__ rather than iterating the Flag directly: since Python
-        # 3.11 (e.g. Ubuntu 24.04's Python 3.12) iterating a Flag omits the zero
-        # member (NONE) and composite members (MEMORY_SAFETY), which would drop
-        # them from the valid choices.
+        # Use __members__ rather than iterating the Flag directly: since
+        # Python 3.11 (Ubuntu 24.04 ships 3.12) Flag iteration omits the zero
+        # member (NONE) and composite members (MEMORY_SAFETY), which would
+        # drop them from the valid choices.
         choices=list(VProperty.__members__.values()),
         default=VProperty.NONE,
         type=VProperty.argparse,

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -492,7 +492,11 @@ def arguments():
         '--check',
         metavar='PROPERTY',
         nargs='+',
-        choices=list(VProperty),
+        # Use __members__ rather than iterating the Flag directly: since Python
+        # 3.11 (e.g. Ubuntu 24.04's Python 3.12) iterating a Flag omits the zero
+        # member (NONE) and composite members (MEMORY_SAFETY), which would drop
+        # them from the valid choices.
+        choices=list(VProperty.__members__.values()),
         default=VProperty.NONE,
         type=VProperty.argparse,
         action=PropertyAction,


### PR DESCRIPTION
## Summary

Adds install and runtime support for Ubuntu 24.04 (noble), and moves CI and
the Docker image to 24.04.

Getting SMACK working on 24.04 required both an install-path change and a
Python-version compatibility fix:

### `bin/build.sh` — install support for 24.04
- Recognize `24.04` / `noble` in the distro `case` patterns.
- **LLVM 14** is installed from Ubuntu's own `universe` repo. `apt.llvm.org`
  has no `llvm-toolchain-noble-14` feed (its earliest for noble is 17), and
  noble ships `clang-14` / `llvm-14-dev` (`14.0.6`) natively. This also avoids
  the now-removed `apt-key` on noble.
- **.NET 6** is installed from Canonical's `ppa:dotnet/backports`. Microsoft no
  longer publishes to `packages.microsoft.com` for 24.04 and .NET 6 is not in
  the noble archive. Using the backports PPA keeps Corral/Boogie on the **same
  .NET 6 runtime as 22.04**, rather than forcing them onto .NET 8 via
  `DOTNET_ROLL_FORWARD`.

### `share/smack/top.py` — Python 3.12 compatibility
Ubuntu 24.04 ships Python 3.12. Since Python 3.11, iterating a `Flag` omits the
zero member (`NONE`) and composite members (`MEMORY_SAFETY`), so
`choices=list(VProperty)` silently dropped `none` and `memory-safety` from the
`--check` argument. `smack --check none` / `--check memory-safety` were then
rejected, causing the affected regression tests to report `UNKNOWN`. Building
the choices from `VProperty.__members__.values()` is stable across 3.10 and
3.12.

### `share/smack/svcomp/toSVCOMPformat.py`
Use a raw string for a regex to silence a Python 3.12
`SyntaxWarning: invalid escape sequence '\.'` (no behavior change).

### CI / Docker
- `.github/workflows/smack-ci.yaml`: both jobs `runs-on: ubuntu-24.04`.
- `Dockerfile`: `FROM ubuntu:22.04` → `ubuntu:24.04`.

## Testing
- Builds successfully on Ubuntu 24.04.
- `test/regtest.py --exhaustive --folder=c/targeted-checks` passes 84/84
  (0 failed / 0 unknown), including the 4 `--check none` / `--check
  memory-safety` tests that previously reported `UNKNOWN`.
- `py_compile -W error::SyntaxWarning` is clean across the Python sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)