### PR TITLE
Implement documentation roadmap and fix no-op asserts in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 <img src="docs/smack-logo.png" width=400 alt="SMACK Logo" align="right">
 
 SMACK is both a *modular software verification toolchain* and a
-*self-contained software verifier*. It can be used to verify the assertions
-in its input programs. In its default mode, assertions are verified up to a
-given bound on loop iterations and recursion depth. SMACK handles complicated
-features of the C language, including dynamic memory allocation, pointer
-arithmetic, and bitwise operations.
+*self-contained software verifier*. It searches for violations of assertions
+in its input programs. In its default mode, that search is bounded by loop
+iterations and recursion depth; its precision also depends on the selected
+translation models and encodings. SMACK handles complicated features of the C
+language, including dynamic memory allocation, pointer arithmetic, and bitwise
+operations.
 
 Under the hood, SMACK is a translator from the [LLVM](http://www.llvm.org)
 compiler's popular intermediate representation (IR) into the

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@
 SMACK is both a *modular software verification toolchain* and a
 *self-contained software verifier*. It can be used to verify the assertions
 in its input programs. In its default mode, assertions are verified up to a
-given bound on loop iterations and recursion depth; it contains experimental
-support for unbounded verification as well. SMACK handles complicated feature
-of the C language, including dynamic memory allocation, pointer arithmetic, and
-bitwise operations.
+given bound on loop iterations and recursion depth. SMACK handles complicated
+features of the C language, including dynamic memory allocation, pointer
+arithmetic, and bitwise operations.
 
 Under the hood, SMACK is a translator from the [LLVM](http://www.llvm.org)
 compiler's popular intermediate representation (IR) into the

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ benchmarking of SMACK.
 
 1. [System Requirements and Installation](docs/installation.md)
 1. [Running SMACK](docs/running.md)
+1. [Command-Line Options](docs/command-line-options.md)
+1. [Build Workflows](docs/build-workflows.md)
+1. [Advanced Modeling](docs/advanced.md)
+1. [Troubleshooting](docs/troubleshooting.md)
+1. [Usage Notes](docs/usage-notes.md)
 1. [Demos](docs/demos.md)
 1. [FAQ](docs/faq.md)
 1. [Inline Boogie Code](docs/boogie-code.md)
@@ -61,4 +66,3 @@ benchmarking of SMACK.
 1. [Projects](docs/projects.md)
 1. [Publications](docs/publications.md)
 1. [People](docs/people.md)
-

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -48,11 +48,12 @@ Contracts are declared in `smack-contracts.h`:
 #include "smack.h"
 #include "smack-contracts.h"
 #include <assert.h>
+#include <limits.h>
 
 int g;
 
 void inc(void) {
-  requires(g >= 0);
+  requires(g >= 0 && g < INT_MAX);
   ensures(g > 0);
   g++;
 }
@@ -64,11 +65,17 @@ Run contract-based verification with Boogie modular mode:
 smack file.c --modular
 ```
 
-The stable user-facing contract forms are:
+Contract support remains experimental. The forms currently exposed by
+`smack-contracts.h` are:
 
 - `requires(expr)` for preconditions
 - `ensures(expr)` for postconditions
 - `invariant(expr)` for loop invariants
+
+The public annotation language does not yet provide a supported expression for
+a function's return value. If a postcondition needs the result, temporarily
+write it through a global variable or output parameter and specify that value
+instead.
 
 Quantified contracts and helpers such as `old` and `result` exist in tests and
 translator internals, but they are not yet exposed as a polished documented C

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,184 @@
+## Advanced Modeling
+
+This page collects SMACK modeling mechanisms that are useful once ordinary
+`assert`, `assume`, and nondeterministic inputs are not expressive enough. These
+features are powerful because they affect the generated Boogie program
+directly; they should be used with small regression tests and with the generated
+`.bpl` inspected when possible.
+
+### Choosing the Right Abstraction
+
+Prefer the least invasive mechanism that expresses the verification problem:
+
+1. Use `__VERIFIER_nondet_<type>()` for unknown inputs.
+2. Use `assume` to restrict the input space.
+3. Use ordinary C helper functions when the model can be written in C.
+4. Use contracts when verifying functions modularly.
+5. Use inline Boogie only when the model needs Boogie-level state, functions, or
+   solver-specific structure.
+
+Overly strong assumptions can make a program verify vacuously. When adding a
+model, also add a failing regression that demonstrates the model can still find
+the intended class of bugs.
+
+### Nondeterministic Values and Assumptions
+
+SMACK declares nondeterministic functions in `smack.h`:
+
+```C
+#include "smack.h"
+#include <assert.h>
+
+int main(void) {
+  int x = __VERIFIER_nondet_int();
+  assume(0 <= x && x < 10);
+  assert(x < 10);
+}
+```
+
+The call to `assume` prunes executions where the condition is false. If the
+assumption is inconsistent, the verifier has no remaining executions to check,
+so every assertion after it will appear to verify.
+
+### Source-Level Contracts
+
+Contracts are declared in `smack-contracts.h`:
+
+```C
+#include "smack.h"
+#include "smack-contracts.h"
+#include <assert.h>
+
+int g;
+
+void inc(void) {
+  requires(g >= 0);
+  ensures(g > 0);
+  g++;
+}
+```
+
+Run contract-based verification with Boogie modular mode:
+
+```Shell
+smack file.c --modular
+```
+
+The stable user-facing contract forms are:
+
+- `requires(expr)` for preconditions
+- `ensures(expr)` for postconditions
+- `invariant(expr)` for loop invariants
+
+Quantified contracts and helpers such as `old` and `result` exist in tests and
+translator internals, but they are not yet exposed as a polished documented C
+API in `smack-contracts.h`. Treat them as experimental until the header and
+documentation are made consistent.
+
+### Inline Boogie
+
+SMACK recognizes several functions from `smack.h` specially:
+
+```C
+void __SMACK_code(const char *fmt, ...);
+void __SMACK_decl(const char *fmt, ...);
+void __SMACK_top_decl(const char *fmt, ...);
+void __SMACK_mod(const char *fmt, ...);
+```
+
+`__SMACK_code` emits a Boogie statement in the current procedure.
+`__SMACK_decl` emits a procedure-local Boogie declaration.
+`__SMACK_top_decl` emits a top-level Boogie declaration.
+`__SMACK_mod` adds a modular-verification modifies clause.
+
+The format string uses `@` as a placeholder for later C arguments. SMACK
+replaces each placeholder with the corresponding translated Boogie expression:
+
+```C
+int y = __VERIFIER_nondet_int();
+__SMACK_code("@ := FOO(@);", y, x);
+```
+
+For promoted variadic arguments, use a type suffix to tell SMACK which original
+C type should be translated. Common suffixes include `@i` for `int`, `@I` for
+`unsigned int`, `@h` for `signed short`, `@H` for `unsigned short`, `@c` for
+`char`, and `@f` for `float`.
+
+See [Inline Boogie Code](boogie-code.md) for the full placeholder discussion.
+
+### Custom Uninterpreted Functions
+
+Inline Boogie is often used to introduce an uninterpreted function that abstracts
+a complex operation:
+
+```C
+#include "smack.h"
+#include <assert.h>
+
+int model(int x) {
+  int y = __VERIFIER_nondet_int();
+  __SMACK_top_decl("function FOO(x: int): int;");
+  __SMACK_code("@ := FOO(@);", y, x);
+  return y;
+}
+
+int main(void) {
+  assert(model(42) == model(42));
+}
+```
+
+Because `FOO` is a mathematical function in Boogie, the two calls with the same
+argument are equal. Add axioms only when necessary:
+
+```C
+__SMACK_top_decl("axiom (forall x: int :: FOO(x) >= 0);");
+```
+
+An inconsistent axiom set makes verification meaningless, because it can prove
+anything. Keep axioms local, small, and covered by regression tests.
+
+### Model Initialization
+
+Use `__SMACK_INIT(name)` to emit setup code before user entry points execute.
+This is useful for model state:
+
+```C
+#include "smack.h"
+
+__SMACK_INIT(defineStates) {
+  __SMACK_top_decl("const unique $idle: int;");
+  __SMACK_top_decl("var $state: [ref]int;");
+}
+
+__SMACK_INIT(initStates) {
+  __SMACK_code("assume (forall x: ref :: $state[x] == $idle);");
+}
+```
+
+Initialization hooks are how SMACK's runtime libraries set up memory and
+pthread model state. Keep declarations and assumptions separate when that makes
+the model easier to inspect in the generated `.bpl`.
+
+### Value Trace Annotations
+
+SMACK exposes helper functions that annotate values for counterexample traces:
+
+```C
+smack_value_t __SMACK_value();
+smack_value_t __SMACK_values(void *ary, unsigned count);
+smack_value_t __SMACK_return_value(void);
+```
+
+These are primarily useful when writing runtime models and test harnesses where
+the default trace would hide the diagnostic value you care about.
+
+### Modeling Guidelines
+
+- Keep C models executable-looking when possible; use inline Boogie only for
+  facts that cannot be expressed cleanly in C.
+- Pair every abstraction with at least one positive and one negative regression.
+- Inspect `-bpl` output when adding `__SMACK_code` or top-level declarations.
+- Avoid global axioms over large domains unless the property really needs them.
+- Prefer `assume` for environmental constraints and `assert` for obligations.
+- Do not hide unsupported behavior silently; emit a warning or keep an explicit
+  failing test when the model is approximate.

--- a/docs/build-workflows.md
+++ b/docs/build-workflows.md
@@ -1,0 +1,153 @@
+## Build Workflows
+
+SMACK verifies the LLVM module produced from the files you pass on the command
+line. For a single C file this is hidden behind `smack file.c`; for larger
+programs it helps to understand where the compilation and linking steps happen.
+
+### Single Source File
+
+For one C file, pass it directly to SMACK:
+
+```Shell
+smack main.c
+```
+
+SMACK invokes Clang with debug information enabled, links in the relevant SMACK
+runtime model, translates the resulting LLVM bitcode to Boogie, and invokes the
+selected verifier.
+
+Use `--clang-options` for ordinary compiler flags:
+
+```Shell
+smack main.c --clang-options="-Iinclude -DVERIFYING"
+```
+
+### Multiple Source Files
+
+Pass every translation unit needed for the verification target:
+
+```Shell
+smack main.c account.c ledger.c
+```
+
+SMACK compiles each source file to LLVM bitcode and links the bitcode modules
+before verification. This is the preferred workflow for small projects and for
+regressions.
+
+The `examples/simple-project` directory shows this pattern with two C files,
+`simple.c` and `incr.c`.
+
+### Saving Intermediate Artifacts
+
+Use these options when you need to inspect or reuse intermediate files:
+
+```Shell
+smack main.c helper.c -bc main.bc -ll main.ll -bpl main.bpl
+```
+
+- `-bc` saves the initial LLVM bitcode.
+- `-ll` saves the LLVM IR after SMACK's LLVM passes.
+- `-bpl` saves the generated Boogie program.
+- `-t` translates only and skips verification.
+
+For example:
+
+```Shell
+smack main.c helper.c -t -bpl main.bpl
+```
+
+This is useful when debugging translation issues or when passing Boogie to a
+separate verifier invocation.
+
+### Prelinked LLVM Bitcode
+
+For larger builds, generate one whole-program bitcode file yourself and pass it
+to SMACK:
+
+```Shell
+clang -c -emit-llvm -O0 -g -Xclang -disable-O0-optnone \
+  -I/path/to/smack/share/smack/include main.c -o main.bc
+clang -c -emit-llvm -O0 -g -Xclang -disable-O0-optnone \
+  -I/path/to/smack/share/smack/include helper.c -o helper.bc
+llvm-link main.bc helper.bc -o program.bc
+smack program.bc
+```
+
+Use the same preprocessor defines and include paths that you would use for a
+normal build. SMACK adds its own runtime model during verification, so do not
+manually link `share/smack/lib/*.c` unless you are deliberately experimenting
+with the internals.
+
+### Makefile-Style Build
+
+A project build can produce bitcode by setting the compiler and linker to LLVM
+tools. The `examples/simple-project/Makefile` uses this pattern:
+
+```Makefile
+CC = clang
+LD = llvm-link
+INC = /path/to/smack/share/smack/include
+CFLAGS = -c -Wall -emit-llvm -O0 -g -I$(INC)
+
+SOURCES = incr.c simple.c
+OBJS = $(subst .c,.bc,$(SOURCES))
+
+all: $(OBJS)
+	$(LD) -o simple-project.bc $(OBJS)
+```
+
+After building the bitcode:
+
+```Shell
+smack simple-project.bc
+```
+
+This replaces older documentation that recommended whole-program-llvm as the
+default route. Whole-program-llvm can still be useful in some environments, but
+SMACK does not require it. Prefer direct multi-file invocation or an explicit
+Clang/`llvm-link` bitcode build when writing reproducible documentation and
+tests.
+
+### Existing Build Systems
+
+For a build system you do not want to rewrite, the usual approach is:
+
+1. Identify the compile commands for the translation units you want to verify.
+2. Replace native object generation with `clang -c -emit-llvm`.
+3. Preserve include paths, target flags, and relevant `-D` definitions.
+4. Use `-O0 -g -Xclang -disable-O0-optnone` unless there is a specific reason
+   to verify optimized IR.
+5. Link the resulting `.bc` files with `llvm-link`.
+6. Run SMACK on the linked `.bc` file.
+
+SMACK also has a JSON compilation database front-end, but it is less commonly
+used than direct source or bitcode input. Treat it as an advanced workflow and
+check the generated `.bc`/`.bpl` artifacts when using it.
+
+### Entry Points
+
+By default, SMACK verifies `main`. Use `--entry-points` when the verification
+target is another function:
+
+```Shell
+smack library.c --entry-points verify_account
+```
+
+Multiple entry points are allowed:
+
+```Shell
+smack library.c --entry-points verify_deposit verify_withdraw
+```
+
+### Common Build Problems
+
+- If Clang cannot find `smack.h`, add the installed SMACK include directory with
+  `--clang-options="-I/path/to/smack/share/smack/include"` or add it to the
+  manual bitcode compile command.
+- If the verifier reports unresolved functions, make sure every needed source
+  file or bitcode module was included in the link.
+- If debug traces do not point to useful source locations, compile with `-g`.
+- If optimized IR hides the source shape you expected, start with `-O0` and
+  only move to optimized IR after the property is understood.
+- If assertions appear to be ignored in C/C++, include `<assert.h>` or
+  `<cassert>`.

--- a/docs/build-workflows.md
+++ b/docs/build-workflows.md
@@ -53,30 +53,59 @@ smack main.c helper.c -bc main.bc -ll main.ll -bpl main.bpl
 For example:
 
 ```Shell
-smack main.c helper.c -t -bpl main.bpl
+smack main.c helper.c -t -bc program.bc -bpl main.bpl \
+  --check assertions integer-overflow
 ```
 
 This is useful when debugging translation issues or when passing Boogie to a
-separate verifier invocation.
+separate verifier invocation. Options that affect source compilation must be
+selected when the bitcode is created. In particular,
+`--check integer-overflow` makes SMACK ask Clang to instrument signed overflow
+and shifts. If the saved bitcode is verified later, use the same property
+selection:
+
+```Shell
+smack program.bc --check assertions integer-overflow
+```
 
 ### Prelinked LLVM Bitcode
 
-For larger builds, generate one whole-program bitcode file yourself and pass it
-to SMACK:
+For larger builds, the safest way to generate one whole-program bitcode file is
+to let SMACK compile and link the sources with the intended property options:
 
 ```Shell
-clang -c -emit-llvm -O0 -g -Xclang -disable-O0-optnone \
+smack main.c helper.c -t -bc program.bc \
+  --check assertions integer-overflow
+smack program.bc --check assertions integer-overflow
+```
+
+This preserves the property-specific source instrumentation used by SMACK's
+front end. Passing prebuilt bitcode to SMACK is too late to add instrumentation
+that Clang must insert while compiling the source.
+
+If the build must invoke LLVM tools directly, use the LLVM major version that
+SMACK was built for. This checkout currently uses LLVM 14, so the equivalent
+commands for checking assertions and integer overflow are:
+
+```Shell
+clang-14 -c -emit-llvm -O0 -g -Xclang -disable-O0-optnone \
+  -fsanitize=signed-integer-overflow,shift \
   -I/path/to/smack/share/smack/include main.c -o main.bc
-clang -c -emit-llvm -O0 -g -Xclang -disable-O0-optnone \
+clang-14 -c -emit-llvm -O0 -g -Xclang -disable-O0-optnone \
+  -fsanitize=signed-integer-overflow,shift \
   -I/path/to/smack/share/smack/include helper.c -o helper.bc
-llvm-link main.bc helper.bc -o program.bc
-smack program.bc
+llvm-link-14 main.bc helper.bc -o program.bc
+smack program.bc --check assertions integer-overflow
 ```
 
 Use the same preprocessor defines and include paths that you would use for a
-normal build. SMACK adds its own runtime model during verification, so do not
-manually link `share/smack/lib/*.c` unless you are deliberately experimenting
-with the internals.
+normal build. Reproduce every source-level flag required by the selected SMACK
+configuration; the sanitizer flag above is required for integer-overflow
+checking. Other properties or encodings can require different defines or
+compiler options, which is why using `smack -t -bc` is preferred. SMACK adds
+its own runtime model during verification, so do not manually link
+`share/smack/lib/*.c` unless you are deliberately experimenting with the
+internals.
 
 ### Makefile-Style Build
 
@@ -84,10 +113,11 @@ A project build can produce bitcode by setting the compiler and linker to LLVM
 tools. The `examples/simple-project/Makefile` uses this pattern:
 
 ```Makefile
-CC = clang
-LD = llvm-link
+CC = clang-14
+LD = llvm-link-14
 INC = /path/to/smack/share/smack/include
-CFLAGS = -c -Wall -emit-llvm -O0 -g -I$(INC)
+CFLAGS = -c -Wall -emit-llvm -O0 -g -Xclang -disable-O0-optnone \
+         -fsanitize=signed-integer-overflow,shift -I$(INC)
 
 SOURCES = incr.c simple.c
 OBJS = $(subst .c,.bc,$(SOURCES))
@@ -99,8 +129,13 @@ all: $(OBJS)
 After building the bitcode:
 
 ```Shell
-smack simple-project.bc
+smack simple-project.bc --check assertions integer-overflow
 ```
+
+This Makefile intentionally prepares bitcode for integer-overflow checking. If
+the project checks a different property set, adjust both `CFLAGS` and the
+matching SMACK command. Also update the `-14` suffixes together when using a
+SMACK installation built against a different LLVM major version.
 
 This replaces older documentation that recommended whole-program-llvm as the
 default route. Whole-program-llvm can still be useful in some environments, but
@@ -113,12 +148,18 @@ tests.
 For a build system you do not want to rewrite, the usual approach is:
 
 1. Identify the compile commands for the translation units you want to verify.
-2. Replace native object generation with `clang -c -emit-llvm`.
+2. Replace native object generation with the version-matched compiler, currently
+   `clang-14 -c -emit-llvm`.
 3. Preserve include paths, target flags, and relevant `-D` definitions.
 4. Use `-O0 -g -Xclang -disable-O0-optnone` unless there is a specific reason
    to verify optimized IR.
-5. Link the resulting `.bc` files with `llvm-link`.
-6. Run SMACK on the linked `.bc` file.
+5. Reproduce property-specific compilation flags. In particular, add
+   `-fsanitize=signed-integer-overflow,shift` to every C/C++ compilation when
+   checking `integer-overflow`.
+6. Link the resulting `.bc` files with the version-matched linker, currently
+   `llvm-link-14`.
+7. Run SMACK on the linked `.bc` file with the same property selection used to
+   prepare the sources.
 
 SMACK also has a JSON compilation database front-end, but it is less commonly
 used than direct source or bitcode input. Treat it as an advanced workflow and
@@ -149,5 +190,10 @@ smack library.c --entry-points verify_deposit verify_withdraw
 - If debug traces do not point to useful source locations, compile with `-g`.
 - If optimized IR hides the source shape you expected, start with `-O0` and
   only move to optimized IR after the property is understood.
+- If integer-overflow checking finds nothing in manually compiled bitcode,
+  confirm that every source file was compiled with
+  `-fsanitize=signed-integer-overflow,shift` before linking.
+- If LLVM rejects or misreads a bitcode file, confirm that Clang, `llvm-link`,
+  and SMACK use the same LLVM major version.
 - If assertions appear to be ignored in C/C++, include `<assert.h>` or
   `<cassert>`.

--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -1,0 +1,342 @@
+## Command-Line Options
+
+This page explains the options users most often need, and why those options
+exist. It is checked against the `smack` parser in `share/smack/top.py`. Run
+`smack -h` for the complete authoritative help text.
+
+The general form is:
+
+```Shell
+smack [options] input-files...
+```
+
+### `--unroll`: Look Deeper Into Loops and Recursion
+
+SMACK is bounded by default. It verifies loops and recursion only up to the
+selected bound, which is `1` unless you say otherwise.
+
+```C
+#include "smack.h"
+#include <assert.h>
+
+int main(void) {
+  int i = 0;
+  while (i < 3) {
+    i++;
+  }
+  assert(i != 3);
+}
+```
+
+With the default bound, SMACK may not reach the failing assertion. Increase the
+bound when the behavior you care about needs more iterations:
+
+```Shell
+smack loop.c --unroll 3
+```
+
+Use `--fail-on-loop-exit` when you want to know whether the proof depended on
+cutting off a loop at the bound:
+
+```Shell
+smack loop.c --unroll 3 --fail-on-loop-exit
+```
+
+If SMACK reports:
+
+```text
+SMACK found no errors with unroll bound 3.
+```
+
+that means no error was found within that bound. It is not a proof for
+arbitrarily many iterations unless the selected back-end and mode establish such
+a proof.
+
+### `--integer-encoding` and `--bit-precise`: Choose How Machine Integers Are Modeled
+
+SMACK has to encode C machine integers into SMT formulas. The default is:
+
+```Shell
+--integer-encoding=unbounded-integer
+```
+
+This treats integer values as mathematical integers. It is often faster, but it
+cannot precisely model all machine-integer behavior, especially bitwise
+operators, narrow casts, and wraparound-sensitive code.
+
+For example:
+
+```C
+#include "smack.h"
+#include <assert.h>
+
+int main(void) {
+  unsigned x = __VERIFIER_nondet_unsigned_int();
+  assume(x < 4U);
+  x >>= 2U;
+  assert(x == 0U);
+}
+```
+
+The assertion relies on bit-level shift semantics. Use bit-vectors:
+
+```Shell
+smack shift.c --integer-encoding=bit-vector
+```
+
+Older SMACK discussions and lower-level `llvm2bpl` invocations may call this
+`--bit-precise`. In the `smack` frontend, the user-facing option is
+`--integer-encoding=bit-vector`; internally it forwards `--bit-precise` to
+`llvm2bpl`.
+
+Use wrapped integer encoding when the program intentionally relies on modular
+machine arithmetic but you do not want full bit-vector reasoning:
+
+```Shell
+smack file.c --integer-encoding=wrapped-integer
+```
+
+This is useful for code such as counters, masks, and low-level libraries where
+overflow is expected behavior. It is still an abstraction, so use
+`bit-vector` when the exact bit pattern matters.
+
+### `--check integer-overflow`: Turn C Undefined Overflow Into a Property
+
+Signed overflow in C is undefined behavior. By default, SMACK checks user
+assertions; it does not report every potential overflow unless requested.
+
+```C
+#include "smack.h"
+
+int main(void) {
+  int x = __VERIFIER_nondet_int();
+  int y = __VERIFIER_nondet_int();
+  return x + y;
+}
+```
+
+Ask SMACK to instrument overflow checks:
+
+```Shell
+smack overflow.c --check integer-overflow
+```
+
+This asks whether every checked signed arithmetic operation and shift is safe.
+If only some functions matter, restrict instrumentation:
+
+```Shell
+smack overflow.c --check integer-overflow --checked-functions main
+```
+
+### `--float`: Use Precise Floating-Point Models
+
+Without `--float`, floating-point operations are modeled approximately enough for
+many control-flow questions but not for precise IEEE-style properties.
+
+```C
+#include "smack.h"
+#include <assert.h>
+
+int main(void) {
+  float x = __VERIFIER_nondet_float();
+  assume(x == 0.0f);
+  assert(x + 1.0f == 1.0f);
+}
+```
+
+The assertion needs SMACK to understand floating-point addition and conversion
+rules. Enable the floating-point model:
+
+```Shell
+smack fp.c --float
+```
+
+Some programs that mix floating-point and integer casts also need bit-vector
+integers:
+
+```Shell
+smack fp_cast.c --float --integer-encoding=bit-vector
+```
+
+Floating-point reasoning is substantially heavier than unbounded integer
+reasoning. Use it when the assertion depends on floating-point values, NaNs,
+rounding, signed zero, or conversions.
+
+### `--pthread`: Use the pthread Model
+
+SMACK does not model pthreads just because a program includes `<pthread.h>`.
+Enable the pthread runtime model explicitly:
+
+```C
+#include "smack.h"
+#include <assert.h>
+#include <pthread.h>
+
+int x;
+
+void *worker(void *arg) {
+  x = 1;
+  return 0;
+}
+
+int main(void) {
+  pthread_t tid;
+  pthread_create(&tid, 0, worker, 0);
+  pthread_join(tid, 0);
+  assert(x == 1);
+}
+```
+
+Run:
+
+```Shell
+smack thread.c --pthread
+```
+
+Concurrent verification is also bounded. Increase the context bound when a bug
+needs more thread interleavings:
+
+```Shell
+smack thread.c --pthread --context-bound 2
+```
+
+Use `--max-threads N` when the program can create many threads and you need a
+larger or smaller thread bound.
+
+### `--check memory-safety`: Generate Pointer Checks
+
+User assertions are not the same as memory-safety checks. To check invalid
+dereferences, invalid frees, and leaks, request the memory property:
+
+```C
+#include <stdlib.h>
+
+int main(void) {
+  int *a = malloc(2 * sizeof(int));
+  int x = a[2];
+  free(a);
+  return x;
+}
+```
+
+Run:
+
+```Shell
+smack mem.c --check memory-safety
+```
+
+When debugging a memory report, check the sub-properties separately:
+
+```Shell
+smack mem.c --check valid-deref
+smack mem.c --check valid-free
+smack mem.c --check memleak
+```
+
+### `--entry-points` and `--checked-functions`: Reduce the Target
+
+By default, SMACK starts at `main`:
+
+```Shell
+smack file.c
+```
+
+For library-style verification, choose a different top-level function:
+
+```Shell
+smack account.c --entry-points verify_deposit
+```
+
+`--checked-functions` is different: it restricts where generated property checks
+are emitted. This is useful when a large program has helper code outside the
+current verification target:
+
+```Shell
+smack account.c --check memory-safety --checked-functions verify_deposit
+```
+
+The names are extended regular expressions, and each expression must match the
+whole function name.
+
+### `--verifier` and `--solver`: Change the Back-End
+
+The default verifier is Corral:
+
+```Shell
+smack file.c --verifier=corral
+```
+
+Use Boogie directly for modular verification and for some solver experiments:
+
+```Shell
+smack file.c --verifier=boogie
+```
+
+Select the SMT solver with:
+
+```Shell
+smack file.c --solver=z3
+smack file.c --solver=cvc5
+smack file.c --solver=yices2
+```
+
+Different solvers can behave very differently on quantified formulas, arrays,
+and bit-vectors.
+
+### `-bc`, `-ll`, `-bpl`, and `-t`: Inspect What SMACK Generated
+
+When the result is surprising, save intermediate artifacts:
+
+```Shell
+smack file.c -t -bc file.bc -ll file.ll -bpl file.bpl
+```
+
+- `-bc` saves the initial LLVM bitcode.
+- `-ll` saves the final LLVM IR used by the translator.
+- `-bpl` saves the generated Boogie program.
+- `-t` stops after translation and skips verification.
+
+This is the fastest way to tell whether the issue is in the frontend, SMACK's
+LLVM passes, the LLVM-to-Boogie translation, or the back-end verifier.
+
+### Less Common but Useful Options
+
+- `--clang-options OPTIONS`
+  Pass include paths, defines, target flags, or warning options to Clang.
+
+- `--warn=silent|approximate|info`
+  Control warnings about approximations and translation information.
+
+- `--mem-mod=no-reuse-impls|no-reuse|reuse`
+  Select the memory model. The default is `no-reuse-impls`.
+
+- `--pointer-encoding=unbounded-integer|bit-vector`
+  Select pointer encoding. The default is `unbounded-integer`.
+
+- `--llvm-assumes=none|use|check`
+  Control how LLVM `assume` intrinsics are handled.
+
+- `--modular`
+  Enable contracts-based modular deductive verification through Boogie.
+
+- `--strings`
+  Include SMACK's string library model.
+
+- `--rewrite-bitwise-ops`
+  Try SMACK's models for some bitwise operations when not using bit-vectors.
+
+- `--static-unroll`
+  Run LLVM's static loop unrolling pass before translation.
+
+- `--transform-bpl COMMAND` and `--transform-out COMMAND`
+  Hook custom post-processing into generated Boogie or verifier output.
+
+For full syntax and all specialized options, run:
+
+```Shell
+smack -h
+```
+
+For workflows that combine these options, see [Running SMACK](running.md),
+[Build Workflows](build-workflows.md), [Advanced Modeling](advanced.md), and
+[Troubleshooting](troubleshooting.md).

--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -10,6 +10,27 @@ The general form is:
 smack [options] input-files...
 ```
 
+### `--check`: Select the Properties to Verify
+
+With no `--check` option, SMACK checks user assertions. Supplying `--check`
+replaces that default; it does not add properties alongside assertions. For
+example, this checks integer overflow but not user assertions:
+
+```Shell
+smack file.c --check integer-overflow
+```
+
+List every property that you want checked. To retain assertion checking while
+also checking memory safety or integer overflow, use:
+
+```Shell
+smack file.c --check assertions memory-safety
+smack file.c --check assertions integer-overflow
+```
+
+`memory-safety` is shorthand for the `valid-deref`, `valid-free`, and `memleak`
+properties.
+
 ### `--unroll`: Look Deeper Into Loops and Recursion
 
 SMACK is bounded by default. It verifies loops and recursion only up to the
@@ -32,25 +53,40 @@ With the default bound, SMACK may not reach the failing assertion. Increase the
 bound when the behavior you care about needs more iterations:
 
 ```Shell
-smack loop.c --unroll 3
+smack loop.c --unroll 4
 ```
 
-Use `--fail-on-loop-exit` when you want to know whether the proof depended on
-cutting off a loop at the bound:
+For this loop, the fourth visit to the loop header is needed to take the exit
+after the three iterations. A bound of `3` still does not reach the assertion.
+
+`--fail-on-loop-exit` inserts a failing assertion in each normal loop exit
+block. A loop-exit report therefore says that a normal exit was reachable in
+the selected model and bound:
 
 ```Shell
-smack loop.c --unroll 3 --fail-on-loop-exit
+smack loop.c --unroll 4 --fail-on-loop-exit
 ```
+
+This sample's user assertion is also reachable at bound `4`. To exercise only
+the injected loop-exit check, remove the user assertion; a report naming
+`__SMACK_loop_exit` is from the injected check.
+
+This option does not report paths that the verifier cuts off when the unroll
+bound is exhausted. It therefore cannot, by itself, show that a successful
+result was independent of the bound.
 
 If SMACK reports:
 
 ```text
-SMACK found no errors with unroll bound 3.
+SMACK found no errors with unroll bound 4.
 ```
 
-that means no error was found within that bound. It is not a proof for
-arbitrarily many iterations unless the selected back-end and mode establish such
-a proof.
+that means no error was found in the selected translation and models within
+that bound. It is not a proof for arbitrarily many iterations unless the
+selected back-end and mode establish such a proof, and translation
+approximations are separate from bounding. In particular, a counterexample
+from an approximate integer, bitwise, or floating-point model need not be a
+concrete C execution.
 
 ### `--integer-encoding` and `--bit-precise`: Choose How Machine Integers Are Modeled
 
@@ -62,7 +98,10 @@ SMACK has to encode C machine integers into SMT formulas. The default is:
 
 This treats integer values as mathematical integers. It is often faster, but it
 cannot precisely model all machine-integer behavior, especially bitwise
-operators, narrow casts, and wraparound-sensitive code.
+operators, narrow casts, and wraparound-sensitive code. The abstraction can
+miss a real machine-integer error, so a successful result with this encoding is
+not automatically a bit-precise C-level safety result. Approximate bitwise
+models can also produce spurious counterexamples.
 
 For example:
 
@@ -89,16 +128,16 @@ Older SMACK discussions and lower-level `llvm2bpl` invocations may call this
 `--integer-encoding=bit-vector`; internally it forwards `--bit-precise` to
 `llvm2bpl`.
 
-Use wrapped integer encoding when the program intentionally relies on modular
-machine arithmetic but you do not want full bit-vector reasoning:
+Wrapped integer encoding may be useful when the only required machine behavior
+is arithmetic wraparound and full bit-vector reasoning is too expensive:
 
 ```Shell
 smack file.c --integer-encoding=wrapped-integer
 ```
 
-This is useful for code such as counters, masks, and low-level libraries where
-overflow is expected behavior. It is still an abstraction, so use
-`bit-vector` when the exact bit pattern matters.
+It models wraparound but still approximates bitwise operators. It is therefore
+not the right encoding for masks or other code whose property depends on exact
+bits; use `bit-vector` for those programs.
 
 ### `--check integer-overflow`: Turn C Undefined Overflow Into a Property
 
@@ -121,7 +160,11 @@ Ask SMACK to instrument overflow checks:
 smack overflow.c --check integer-overflow
 ```
 
-This asks whether every checked signed arithmetic operation and shift is safe.
+This selects overflow checking instead of the default assertion checking. Use
+`--check assertions integer-overflow` if both properties matter. The overflow
+property asks whether every checked signed arithmetic operation and shift is
+safe.
+
 If only some functions matter, restrict instrumentation:
 
 ```Shell
@@ -130,8 +173,10 @@ smack overflow.c --check integer-overflow --checked-functions main
 
 ### `--float`: Use Precise Floating-Point Models
 
-Without `--float`, floating-point operations are modeled approximately enough for
-many control-flow questions but not for precise IEEE-style properties.
+Without `--float`, floating-point operations are modeled with uninterpreted
+functions rather than IEEE floating-point semantics. That over-approximation
+can produce false alarms and counterexample traces that are not concrete C
+executions.
 
 ```C
 #include "smack.h"
@@ -225,6 +270,9 @@ Run:
 smack mem.c --check memory-safety
 ```
 
+This invocation selects memory safety instead of the default user-assertion
+property. Use `--check assertions memory-safety` to check both.
+
 When debugging a memory report, check the sub-properties separately:
 
 ```Shell
@@ -247,13 +295,20 @@ For library-style verification, choose a different top-level function:
 smack account.c --entry-points verify_deposit
 ```
 
-`--checked-functions` is different: it restricts where generated property checks
-are emitted. This is useful when a large program has helper code outside the
-current verification target:
+`--checked-functions` is different: it filters user assertions and many
+source-function-local generated checks, including valid-dereference and integer
+overflow checks, by the function containing the check. Assertions in functions
+that do not match are omitted, even if those functions remain reachable from an
+entry point. For example:
 
 ```Shell
-smack account.c --check memory-safety --checked-functions verify_deposit
+smack account.c --check assertions valid-deref \
+  --checked-functions verify_deposit
 ```
+
+This filter does not cover every property. In particular, `valid-free` checks
+are implemented in the shared `free` model and are not removed according to the
+calling function's name.
 
 The names are extended regular expressions, and each expression must match the
 whole function name.
@@ -317,7 +372,8 @@ LLVM passes, the LLVM-to-Boogie translation, or the back-end verifier.
   Control how LLVM `assume` intrinsics are handled.
 
 - `--modular`
-  Enable contracts-based modular deductive verification through Boogie.
+  Enable the experimental contracts-based modular deductive verification mode
+  through Boogie.
 
 - `--strings`
   Include SMACK's string library model.

--- a/docs/running.md
+++ b/docs/running.md
@@ -6,9 +6,9 @@ For a given input C/C++ program, the tool checks for violations of user-provided
 assertions, as well as automatically generated assertions for built-in property
 checks such as memory safety and integer overflow (see [Checking Memory
 Safety](#checking-memory-safety) and [Checking Integer
-Overflow](#checking-integer-overflow) below). SMACK has a number of command line
+Overflow](#checking-integer-overflow) below). SMACK has a number of command-line
 options that can be used to fine-tune the toolchain. Type `smack -h` for a full
-list of supported command line options.
+list of supported command-line options.
 
 
 ### Using The SMACK Verifier
@@ -306,6 +306,10 @@ that must be installed separately — selected with `--solver`:
 smack simple.c --solver=cvc5
 ```
 
-Run `smack -h` for the complete list of command line options. For more advanced
-usage scenarios, please refer to our [usage notes](usage-notes.md).
-
+Run `smack -h` for the complete command-line help. For explanations of the
+options users most commonly need, including `--unroll`,
+`--integer-encoding=bit-vector`, `--float`, and `--pthread`, see
+[Command-Line Options](command-line-options.md). For larger programs, see
+[Build Workflows](build-workflows.md). For custom models and inline Boogie, see
+[Advanced Modeling](advanced.md). For common failure modes, see
+[Troubleshooting](troubleshooting.md).

--- a/docs/running.md
+++ b/docs/running.md
@@ -3,9 +3,12 @@
 
 SMACK software verifier is run using the `smack` tool in the bin directory.
 For a given input C/C++ program, the tool checks for violations of user-provided
-assertions. SMACK has a number of command line options that can be used
-to fine-tune the toolchain. Type `smack -h` for a full list of supported command
-line options.
+assertions, as well as automatically generated assertions for built-in property
+checks such as memory safety and integer overflow (see [Checking Memory
+Safety](#checking-memory-safety) and [Checking Integer
+Overflow](#checking-integer-overflow) below). SMACK has a number of command line
+options that can be used to fine-tune the toolchain. Type `smack -h` for a full
+list of supported command line options.
 
 
 ### Using The SMACK Verifier
@@ -15,6 +18,7 @@ verifier:
 ```C
 // examples/simple/simple.c
 #include "smack.h"
+#include <assert.h>
 #include <stdlib.h>
 
 #define TRUE 1
@@ -94,16 +98,37 @@ int main(void) {
   return 0;
 }
 ```
-Note that this example can also be found in the smack/examples/simple
-directory. SMACK defines a number of functions (one for each basic type)
-for introducing nondeterministic (i.e., unconstrained) values, such as
-`__VERIFIER_nondet_int` used in this example.
+Note that this example can also be found in the `examples/simple` directory. It
+uses the three building blocks that SMACK programs rely on to express
+verification problems:
+
+- **`__VERIFIER_nondet_<type>()`** returns an unconstrained (i.e.,
+  *nondeterministic*) value of the given type. SMACK reasons about *all*
+  possible return values simultaneously, so these functions are used to model
+  arbitrary or unknown inputs. SMACK defines one such function for each basic
+  type, e.g., `__VERIFIER_nondet_int` (used above) and
+  `__VERIFIER_nondet_unsigned_long`. They are declared in `smack.h`.
+- **`assert(cond)`** states a property that must hold on every execution. If
+  SMACK finds any execution that reaches the assertion with `cond` evaluating to
+  false, it reports an error along with a counterexample trace; otherwise the
+  assertion is verified. `assert` is the standard C macro: SMACK ships its own
+  `<assert.h>` (and `<cassert>` for C++) that connects it to the verifier, so
+  **you must `#include <assert.h>`** for your assertions to be checked. If you
+  forget it, Clang emits an *implicit declaration of function 'assert'* warning
+  and the assertions are silently ignored.
+- **`assume(cond)`** restricts verification to the executions in which `cond`
+  holds. It is typically used to constrain nondeterministic inputs — for
+  example, `assume(x > 0)` discards every execution in which `x <= 0`. `assume`
+  is provided by `smack.h`.
 
 Simply run the SMACK verifier on your input C file:
 ```Shell
 smack simple.c
 ```
-SMACK should report no errors for this example.
+SMACK should report no errors for this example:
+```
+SMACK found no errors with unroll bound 1.
+```
 
 Under the hood, SMACK first compiles the example into an LLVM bitcode file using Clang:
 ```Shell
@@ -114,5 +139,173 @@ verifier leverages to generate more informative error traces. Then, the generate
 file is translated into Boogie code, which is in turn passed to the chosen back-end
 verifier.
 
-For mode advanced usage scenarios, please refer to our [usage notes](usage-notes.md).
+### Understanding SMACK's Output
+
+When SMACK finishes, it reports one of two outcomes.
+
+If no assertion — user-written or automatically generated — can be violated
+within the current bounds, SMACK reports success:
+```
+SMACK found no errors with unroll bound 1.
+```
+Recall that SMACK is a *bounded* verifier: by default it unrolls loops and
+recursion only once (`--unroll 1`). "No errors with unroll bound `N`" therefore
+means the program is safe along every execution that stays within that bound; a
+bug that only manifests after more iterations may be missed. Increase the bound
+with `--unroll N` to explore deeper (the [usage notes](usage-notes.md) discuss
+how to choose a bound).
+
+If an assertion can be violated, SMACK reports an error together with a
+counterexample trace. The following program asserts a property that does not hold
+for every allowed input:
+```C
+// buggy.c
+#include "smack.h"
+#include <assert.h>
+
+int main(void) {
+  int x = __VERIFIER_nondet_int();
+  assume(x >= 5);
+  assert(x >= 10); // fails, e.g., when x == 5
+  return 0;
+}
+```
+```Shell
+smack buggy.c
+```
+```
+buggy.c(5,11): CALL __VERIFIER_nondet_int
+...
+buggy.c(5,11): RETURN from __VERIFIER_nondet_int, ... x = 8
+buggy.c(7,3): CALL __VERIFIER_assert
+...
+SMACK found an error.
+```
+The trace lists the steps of a concrete execution that reaches the failing
+assertion, annotated with source locations (`file(line,column)`) and the values
+of variables along the way. Here it exhibits `x = 8`, which satisfies
+`assume(x >= 5)` but violates `assert(x >= 10)`, as a counterexample. The `-g`
+debug information that SMACK compiles with is what makes these source-level
+traces possible.
+
+### Checking Memory Safety
+
+Beyond user-written assertions, SMACK can automatically check that a program is
+*memory safe*. When memory-safety checking is enabled, SMACK instruments the
+program with generated assertions that guard every memory access and
+deallocation, so no assertions need to be written by hand. The `memory-safety`
+property is the union of three sub-properties, each of which can also be checked
+on its own:
+
+- `valid-deref` — every pointer dereference targets a live, in-bounds object
+- `valid-free` — every `free` releases a heap object exactly once
+- `memleak` — every allocated object is eventually freed
+
+Consider the following program, which reads one element past the end of a
+ten-element array:
+```C
+// memsafe.c
+#include "smack.h"
+#include <stdlib.h>
+
+int main(void) {
+  int *a = malloc(10 * sizeof(int));
+  int x = a[10]; // out-of-bounds read: valid indices are 0..9
+  free(a);
+  return x;
+}
+```
+Running SMACK with the `--check memory-safety` option detects the buffer
+overflow:
+```Shell
+smack memsafe.c --check memory-safety
+```
+```
+SMACK found an error: invalid pointer dereference.
+```
+Pass `--check valid-deref`, `--check valid-free`, or `--check memleak` instead to
+check an individual sub-property.
+
+### Checking Integer Overflow
+
+SMACK can also check for signed integer overflow, which is undefined behavior in
+C. With the `--check integer-overflow` option, SMACK inserts a generated
+assertion before each arithmetic operation that could overflow, verifying that
+the result stays within the range of its type.
+
+The following program adds two nondeterministic integers, whose sum may exceed
+the maximum value representable by an `int`:
+```C
+// overflow.c
+#include "smack.h"
+
+int main(void) {
+  int x = __VERIFIER_nondet_int();
+  int y = __VERIFIER_nondet_int();
+  return x + y; // may overflow the range of int
+}
+```
+```Shell
+smack overflow.c --check integer-overflow
+```
+SMACK finds inputs that trigger the overflow and prints a trace leading to it:
+```
+overflow.c(4,11): ... x = 2147482411
+overflow.c(5,11): ... y = 1237
+SMACK found an error: integer overflow.
+```
+By default every function is checked; use `--checked-functions` to restrict
+property checking to a specific set of functions, for example
+`--checked-functions main compute`.
+
+### Verifying Programs That Span Multiple Files
+
+Real-world programs are usually split across several source files. SMACK accepts
+multiple input files on the command line, compiling each one and linking the
+resulting LLVM bitcode into a single whole-program module before verification:
+```Shell
+smack simple.c incr.c
+```
+```
+SMACK found no errors with unroll bound 1.
+```
+A complete two-file example is available in the `examples/simple-project`
+directory.
+
+For larger projects, you can instead produce a single whole-program LLVM bitcode
+file yourself and hand that file to SMACK. Compile each translation unit to
+bitcode with `clang -c -emit-llvm -g`, link the results together with
+`llvm-link`, and run SMACK on the combined bitcode. The `Makefile` in the
+`examples/simple-project` directory automates exactly these steps, producing a
+`simple-project.bc` that you can verify directly:
+```Shell
+smack simple-project.bc
+```
+
+### Selecting a Verification Back-end and Solver
+
+SMACK translates the input program into Boogie and then discharges it with a
+back-end verification engine, selected with `--verifier`:
+
+- **`corral`** (the default) is a bounded model checker that inlines procedures
+  and unrolls loops up to the given bound. It is also the engine used for
+  concurrent programs (see `--pthread` and `--context-bound` in the
+  [usage notes](usage-notes.md)).
+- **`boogie`** discharges verification conditions with an SMT solver. It is a
+  useful alternative, in particular when experimenting with modular,
+  contract-based verification.
+
+For example, to verify the introductory program with Boogie instead of Corral:
+```Shell
+smack simple.c --verifier=boogie
+```
+Underneath either engine, an SMT solver decides the generated formulas. SMACK
+uses Z3 by default and can also use CVC5 or Yices2 — each an optional dependency
+that must be installed separately — selected with `--solver`:
+```Shell
+smack simple.c --solver=cvc5
+```
+
+Run `smack -h` for the complete list of command line options. For more advanced
+usage scenarios, please refer to our [usage notes](usage-notes.md).
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -2,13 +2,15 @@
 
 
 SMACK software verifier is run using the `smack` tool in the bin directory.
-For a given input C/C++ program, the tool checks for violations of user-provided
-assertions, as well as automatically generated assertions for built-in property
-checks such as memory safety and integer overflow (see [Checking Memory
-Safety](#checking-memory-safety) and [Checking Integer
-Overflow](#checking-integer-overflow) below). SMACK has a number of command-line
-options that can be used to fine-tune the toolchain. Type `smack -h` for a full
-list of supported command-line options.
+For a given input C/C++ program, the tool checks selected properties. With no
+`--check` option, the selected property set consists of user-provided
+assertions. The `--check` option can instead select automatically generated
+checks such as
+memory safety and integer overflow, or select those checks together with
+`assertions` (see [Checking Memory Safety](#checking-memory-safety) and
+[Checking Integer Overflow](#checking-integer-overflow) below). SMACK has a
+number of command-line options that can be used to fine-tune the toolchain. Type
+`smack -h` for a full list of supported command-line options.
 
 
 ### Using The SMACK Verifier
@@ -108,14 +110,16 @@ verification problems:
   arbitrary or unknown inputs. SMACK defines one such function for each basic
   type, e.g., `__VERIFIER_nondet_int` (used above) and
   `__VERIFIER_nondet_unsigned_long`. They are declared in `smack.h`.
-- **`assert(cond)`** states a property that must hold on every execution. If
-  SMACK finds any execution that reaches the assertion with `cond` evaluating to
-  false, it reports an error along with a counterexample trace; otherwise the
-  assertion is verified. `assert` is the standard C macro: SMACK ships its own
-  `<assert.h>` (and `<cassert>` for C++) that connects it to the verifier, so
-  **you must `#include <assert.h>`** for your assertions to be checked. If you
-  forget it, Clang emits an *implicit declaration of function 'assert'* warning
-  and the assertions are silently ignored.
+- **`assert(cond)`** states a property that must hold. If SMACK finds an
+  execution in its verification model that reaches the assertion with `cond`
+  evaluating to false, it reports an error along with a counterexample trace.
+  Otherwise, no violation of that assertion was found under the selected model
+  and bounds. `assert` is the standard C macro: SMACK ships its own `<assert.h>`
+  (and `<cassert>` for C++) that connects it to the verifier, so **you must
+  `#include <assert.h>`** for your assertions to be checked. If you forget it,
+  Clang can emit an *implicit declaration of function 'assert'* warning in C
+  and silently ignore the assertions; C++ normally rejects the undeclared
+  identifier.
 - **`assume(cond)`** restricts verification to the executions in which `cond`
   holds. It is typically used to constrain nondeterministic inputs — for
   example, `assume(x > 0)` discards every execution in which `x <= 0`. `assume`
@@ -125,14 +129,16 @@ Simply run the SMACK verifier on your input C file:
 ```Shell
 smack simple.c
 ```
-SMACK should report no errors for this example:
+Because this invocation does not specify `--check`, SMACK checks the program's
+assertions. It should report no errors for this example:
 ```
 SMACK found no errors with unroll bound 1.
 ```
 
-Under the hood, SMACK first compiles the example into an LLVM bitcode file using Clang:
+Under the hood, SMACK first compiles the example into an LLVM bitcode file using
+the Clang version from its configured LLVM toolchain (LLVM 14 for this release):
 ```Shell
-clang -c -Wall -emit-llvm -O0 -g -Xclang -disable-O0-optnone -I../../share/smack/include simple.c -o simple.bc
+clang-14 -c -Wall -emit-llvm -O0 -g -Xclang -disable-O0-optnone -I../../share/smack/include simple.c -o simple.bc
 ```
 We use the `-g` flag to compile with debug information enabled, which the SMACK
 verifier leverages to generate more informative error traces. Then, the generated bitcode
@@ -141,19 +147,25 @@ verifier.
 
 ### Understanding SMACK's Output
 
-When SMACK finishes, it reports one of two outcomes.
+When SMACK finishes, it reports one of four result kinds: it found no errors, it
+found an error, it timed out, or the result is unknown. A timeout or unknown
+result is inconclusive; neither establishes a property nor supplies a confirmed
+counterexample.
 
-If no assertion — user-written or automatically generated — can be violated
-within the current bounds, SMACK reports success:
+If the back-end finds no violation of the selected properties in the generated
+verification model within the current bounds, SMACK reports:
 ```
 SMACK found no errors with unroll bound 1.
 ```
 Recall that SMACK is a *bounded* verifier: by default it unrolls loops and
 recursion only once (`--unroll 1`). "No errors with unroll bound `N`" therefore
-means the program is safe along every execution that stays within that bound; a
-bug that only manifests after more iterations may be missed. Increase the bound
-with `--unroll N` to explore deeper (the [usage notes](usage-notes.md) discuss
-how to choose a bound).
+means only that no error was found for the selected properties in SMACK's model
+within that bound. It is not, by itself, a proof of safety for all C executions.
+A bug that requires more iterations may be missed, and integer, floating-point,
+external-library, or other approximations can make the verification model
+differ from the C program. Increase the bound with `--unroll N` to explore
+deeper (the [usage notes](usage-notes.md) discuss how to choose a bound), and
+choose modeling options appropriate to the property being checked.
 
 If an assertion can be violated, SMACK reports an error together with a
 counterexample trace. The following program asserts a property that does not hold
@@ -174,31 +186,34 @@ int main(void) {
 smack buggy.c
 ```
 ```
-buggy.c(5,11): CALL __VERIFIER_nondet_int
+buggy.c(6,11): CALL __VERIFIER_nondet_int
 ...
-buggy.c(5,11): RETURN from __VERIFIER_nondet_int, ... x = 8
-buggy.c(7,3): CALL __VERIFIER_assert
+buggy.c(6,11): RETURN from __VERIFIER_nondet_int, ... x = 8
+buggy.c(8,3): CALL __VERIFIER_assert
 ...
 SMACK found an error.
 ```
-The trace lists the steps of a concrete execution that reaches the failing
-assertion, annotated with source locations (`file(line,column)`) and the values
-of variables along the way. Here it exhibits `x = 8`, which satisfies
-`assume(x >= 5)` but violates `assert(x >= 10)`, as a counterexample. The `-g`
-debug information that SMACK compiles with is what makes these source-level
-traces possible.
+The trace describes a witness in SMACK's verification model, annotated with
+source locations (`file(line,column)`) and model values along the way. Here it
+exhibits `x = 8`, which satisfies `assume(x >= 5)` but violates
+`assert(x >= 10)`. When the relevant operations are modeled precisely, such a
+witness corresponds to a concrete source execution. Approximate integer,
+floating-point, library, or other models can instead produce an abstract or
+spurious counterexample, so validate suspicious traces against the selected
+modeling options. The `-g` debug information that SMACK compiles with is what
+makes these source-level traces possible.
 
 ### Checking Memory Safety
 
-Beyond user-written assertions, SMACK can automatically check that a program is
-*memory safe*. When memory-safety checking is enabled, SMACK instruments the
-program with generated assertions that guard every memory access and
-deallocation, so no assertions need to be written by hand. The `memory-safety`
-property is the union of three sub-properties, each of which can also be checked
-on its own:
+SMACK can automatically check that a program is *memory safe*. When
+memory-safety checking is enabled, SMACK instruments the program with generated
+assertions that guard every memory access and deallocation, so no assertions
+need to be written by hand. The `memory-safety` property is the union of three
+sub-properties, each of which can also be checked on its own:
 
 - `valid-deref` — every pointer dereference targets a live, in-bounds object
-- `valid-free` — every `free` releases a heap object exactly once
+- `valid-free` — every `free(p)` receives either `NULL` or the base address of a
+  currently allocated heap object
 - `memleak` — every allocated object is eventually freed
 
 Consider the following program, which reads one element past the end of a
@@ -223,15 +238,25 @@ smack memsafe.c --check memory-safety
 ```
 SMACK found an error: invalid pointer dereference.
 ```
+An explicit `--check` list replaces the default `assertions` selection; it does
+not add to it. The command above checks memory safety but would not check any
+user-written assertions in `memsafe.c`. To check both, select both properties:
+
+```Shell
+smack memsafe.c --check assertions memory-safety
+```
+
 Pass `--check valid-deref`, `--check valid-free`, or `--check memleak` instead to
-check an individual sub-property.
+check only an individual sub-property. Include `assertions` in the same list if
+user-written assertions should also be checked.
 
 ### Checking Integer Overflow
 
 SMACK can also check for signed integer overflow, which is undefined behavior in
-C. With the `--check integer-overflow` option, SMACK inserts a generated
-assertion before each arithmetic operation that could overflow, verifying that
-the result stays within the range of its type.
+C. With the `--check integer-overflow` option, SMACK instruments checked signed
+arithmetic and shift operations with generated assertions. These checks cover
+arithmetic results outside the range of their type as well as invalid or
+overflowing shifts.
 
 The following program adds two nondeterministic integers, whose sum may exceed
 the maximum value representable by an `int`:
@@ -250,13 +275,21 @@ smack overflow.c --check integer-overflow
 ```
 SMACK finds inputs that trigger the overflow and prints a trace leading to it:
 ```
-overflow.c(4,11): ... x = 2147482411
-overflow.c(5,11): ... y = 1237
+overflow.c(5,11): ... x = 2147482411
+overflow.c(6,11): ... y = 1237
 SMACK found an error: integer overflow.
 ```
+This command selects only integer-overflow checks. To check user-written
+assertions at the same time, run:
+
+```Shell
+smack overflow.c --check assertions integer-overflow
+```
+
 By default every function is checked; use `--checked-functions` to restrict
 property checking to a specific set of functions, for example
-`--checked-functions main compute`.
+`--checked-functions main compute`. This restriction also suppresses
+user-written assertions in functions whose names do not match.
 
 ### Verifying Programs That Span Multiple Files
 
@@ -273,13 +306,19 @@ A complete two-file example is available in the `examples/simple-project`
 directory.
 
 For larger projects, you can instead produce a single whole-program LLVM bitcode
-file yourself and hand that file to SMACK. Compile each translation unit to
-bitcode with `clang -c -emit-llvm -g`, link the results together with
-`llvm-link`, and run SMACK on the combined bitcode. The `Makefile` in the
-`examples/simple-project` directory automates exactly these steps, producing a
-`simple-project.bc` that you can verify directly:
+file yourself and hand that file to SMACK. Compile each translation unit with
+the Clang version that matches SMACK's configured LLVM toolchain and link the
+results with the matching `llvm-link` (currently `clang-14` and
+`llvm-link-14`). Manual compilation must also reproduce SMACK's frontend flags
+for the selected properties. In particular, add
+`-fsanitize=signed-integer-overflow,shift` when building bitcode for
+`--check integer-overflow`; supplying that property only after the source has
+already been compiled cannot add Clang's overflow instrumentation. See [Build
+Workflows](build-workflows.md) for the complete commands. The `Makefile` in the
+`examples/simple-project` directory demonstrates the basic multi-file pattern,
+producing a `simple-project.bc` that you can verify directly:
 ```Shell
-smack simple-project.bc
+smack simple-project.bc --check assertions integer-overflow
 ```
 
 ### Selecting a Verification Back-end and Solver

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,180 @@
+## Troubleshooting
+
+This page lists common SMACK surprises and the first checks to make before
+digging into the generated LLVM or Boogie.
+
+### My Assertion Is Ignored
+
+In C and C++, include the standard assertion header:
+
+```C
+#include <assert.h>
+```
+
+or:
+
+```C++
+#include <cassert>
+```
+
+SMACK supplies its own header that maps `assert` to verifier assertions. Without
+the include, Clang may only warn about an implicit declaration of `assert`, and
+the property can be compiled as an ordinary unresolved function call.
+
+### "No Errors" Only Means Safe Within the Bound
+
+SMACK is bounded by default. This message:
+
+```text
+SMACK found no errors with unroll bound 1.
+```
+
+means no error was found within one loop or recursion unroll. Increase the bound
+for deeper executions:
+
+```Shell
+smack file.c --unroll 5
+```
+
+Use `--fail-on-loop-exit` when you want SMACK to report executions that leave a
+loop because the bound was exhausted.
+
+### A Bitwise or Cast-Heavy Program Gives a Strange Counterexample
+
+The default integer encoding uses mathematical integers, which is faster but can
+approximate machine-level bit operations. Try:
+
+```Shell
+smack file.c --integer-encoding=bit-vector
+```
+
+For code that intentionally relies on modular arithmetic, also consider:
+
+```Shell
+smack file.c --integer-encoding=wrapped-integer
+```
+
+Bit-vector reasoning is usually slower, so use it when the property depends on
+machine-level integer behavior.
+
+### Floating-Point Results Look Uninterpreted
+
+Enable floating-point modeling:
+
+```Shell
+smack file.c --float
+```
+
+Some mixed floating-point/integer programs also need bit-vector integers:
+
+```Shell
+smack file.c --float --integer-encoding=bit-vector
+```
+
+### Memory-Safety Failures Point Into SMACK Runtime Code
+
+Generated memory-safety checks are assertions inserted by SMACK. A trace may
+show a failure in `smack.c` even though the invalid pointer came from user code.
+Look backward in the trace for the last assignment or call involving the failing
+pointer.
+
+When narrowing a memory issue, check one sub-property at a time:
+
+```Shell
+smack file.c --check valid-deref
+smack file.c --check valid-free
+smack file.c --check memleak
+```
+
+### Clang Cannot Find a Header
+
+Pass include paths through `--clang-options`:
+
+```Shell
+smack file.c --clang-options="-Iinclude -Ithird_party/model/include"
+```
+
+If you compile LLVM bitcode manually, add SMACK's installed include directory to
+the manual Clang invocation:
+
+```Shell
+clang -c -emit-llvm -O0 -g -I/path/to/smack/share/smack/include file.c -o file.bc
+```
+
+### A Multi-File Program Has Unresolved Calls
+
+Pass all source files to SMACK, or link all bitcode files with `llvm-link`:
+
+```Shell
+smack main.c helper.c model.c
+```
+
+or:
+
+```Shell
+llvm-link main.bc helper.bc model.bc -o program.bc
+smack program.bc
+```
+
+### The Trace Has Poor Source Locations
+
+Compile with debug information. SMACK does this by default for source input. If
+you build bitcode manually, include `-g`:
+
+```Shell
+clang -c -emit-llvm -O0 -g file.c -o file.bc
+```
+
+### Boogie, Corral, or the Solver Is Not Found
+
+Check that the verifier and solver executables are in `PATH`:
+
+```Shell
+boogie
+corral
+z3 --version
+```
+
+If you installed SMACK into a custom prefix, source the environment setup you
+use for that installation before running tests.
+
+### Verification Times Out
+
+Try reducing the proof obligation before changing the program:
+
+- Reduce the entry point with `--entry-points`.
+- Restrict generated checks with `--checked-functions`.
+- Lower or raise `--unroll` intentionally rather than leaving it accidental.
+- Check one property at a time with `--check`.
+- Try `--verifier=boogie` or a different `--solver` when the default back-end
+  struggles.
+- Avoid `--integer-encoding=bit-vector` unless the property needs it.
+
+### SMACK Warns About an Approximate Translation
+
+Approximation warnings mean SMACK continued after encountering a feature it does
+not model precisely. Increase warning detail with:
+
+```Shell
+smack file.c --warn=info
+```
+
+If the warning concerns code relevant to the property, treat the result as
+suspect. Reduce the program to a small regression and open an issue.
+
+### I Need to See What SMACK Generated
+
+Save the intermediate artifacts:
+
+```Shell
+smack file.c -t -bc file.bc -ll file.ll -bpl file.bpl
+```
+
+Then inspect:
+
+- `file.bc` for the initial frontend output.
+- `file.ll` for the LLVM IR after SMACK's LLVM passes.
+- `file.bpl` for the Boogie program sent to the verifier.
+
+This is the fastest way to distinguish a frontend issue from an LLVM-to-Boogie
+translation issue.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,11 +17,31 @@ or:
 #include <cassert>
 ```
 
-SMACK supplies its own header that maps `assert` to verifier assertions. Without
-the include, Clang may only warn about an implicit declaration of `assert`, and
-the property can be compiled as an ordinary unresolved function call.
+SMACK supplies its own header that maps `assert` to verifier assertions. In C,
+omitting it can produce only an implicit-declaration warning and compile the
+property as an ordinary unresolved function call; C++ normally rejects the
+undeclared identifier.
 
-### "No Errors" Only Means Safe Within the Bound
+Also check the property selection. With no `--check` option, SMACK checks
+`assertions` by default. An explicit `--check` list replaces that default, so
+this checks memory safety but ignores user-written assertions:
+
+```Shell
+smack file.c --check memory-safety
+```
+
+Select both properties when both are intended:
+
+```Shell
+smack file.c --check assertions memory-safety
+```
+
+Finally, `--checked-functions` suppresses user assertions and many
+function-local generated checks, such as valid-dereference and integer-overflow
+checks, in functions whose names do not match. It does not filter every
+property: `valid-free` checks in the shared `free` model still run.
+
+### "No Errors" Is a Bounded, Model-Relative Result
 
 SMACK is bounded by default. This message:
 
@@ -29,15 +49,20 @@ SMACK is bounded by default. This message:
 SMACK found no errors with unroll bound 1.
 ```
 
-means no error was found within one loop or recursion unroll. Increase the bound
-for deeper executions:
+means no violation of the selected properties was found in SMACK's verification
+model within one loop or recursion unroll. It is not, by itself, a proof that
+the C program is safe: deeper executions can expose errors, and approximate
+modeling can differ from C semantics. Increase the bound for deeper executions:
 
 ```Shell
 smack file.c --unroll 5
 ```
 
-Use `--fail-on-loop-exit` when you want SMACK to report executions that leave a
-loop because the bound was exhausted.
+`--fail-on-loop-exit` does not detect an execution being cut off because its
+bound was exhausted. It inserts a failing assertion on each normal loop exit.
+An error from that assertion shows that a normal exit is reachable at the
+chosen bound; if no loop-exit error is found, try a larger bound (unless the loop
+is intentionally nonterminating).
 
 ### A Bitwise or Cast-Heavy Program Gives a Strange Counterexample
 
@@ -54,8 +79,10 @@ For code that intentionally relies on modular arithmetic, also consider:
 smack file.c --integer-encoding=wrapped-integer
 ```
 
-Bit-vector reasoning is usually slower, so use it when the property depends on
-machine-level integer behavior.
+Wrapped integers model arithmetic wraparound but still approximate bitwise
+operations, so they are not a substitute for bit-vectors when masks or shifts
+matter. Bit-vector reasoning is usually slower, so use it when the property
+depends on machine-level integer behavior.
 
 ### Floating-Point Results Look Uninterpreted
 
@@ -86,6 +113,10 @@ smack file.c --check valid-free
 smack file.c --check memleak
 ```
 
+These commands intentionally select only the named memory property. Add
+`assertions` to the `--check` list if user-written assertions should remain
+enabled.
+
 ### Clang Cannot Find a Header
 
 Pass include paths through `--clang-options`:
@@ -98,12 +129,19 @@ If you compile LLVM bitcode manually, add SMACK's installed include directory to
 the manual Clang invocation:
 
 ```Shell
-clang -c -emit-llvm -O0 -g -I/path/to/smack/share/smack/include file.c -o file.bc
+clang-14 -c -emit-llvm -O0 -g -Xclang -disable-O0-optnone \
+  -I/path/to/smack/share/smack/include file.c -o file.bc
 ```
+
+Use the Clang major version that matches the LLVM version configured for SMACK
+(currently LLVM 14). Manual compilation must also reproduce property-specific
+frontend flags; notably, use `-fsanitize=signed-integer-overflow,shift` before
+running prebuilt bitcode with `--check integer-overflow`.
 
 ### A Multi-File Program Has Unresolved Calls
 
-Pass all source files to SMACK, or link all bitcode files with `llvm-link`:
+Pass all source files to SMACK, or link all bitcode files with the `llvm-link`
+version matching SMACK:
 
 ```Shell
 smack main.c helper.c model.c
@@ -112,7 +150,7 @@ smack main.c helper.c model.c
 or:
 
 ```Shell
-llvm-link main.bc helper.bc model.bc -o program.bc
+llvm-link-14 main.bc helper.bc model.bc -o program.bc
 smack program.bc
 ```
 
@@ -122,7 +160,7 @@ Compile with debug information. SMACK does this by default for source input. If
 you build bitcode manually, include `-g`:
 
 ```Shell
-clang -c -emit-llvm -O0 -g file.c -o file.bc
+clang-14 -c -emit-llvm -O0 -g -Xclang -disable-O0-optnone file.c -o file.bc
 ```
 
 ### Boogie, Corral, or the Solver Is Not Found
@@ -143,7 +181,9 @@ use for that installation before running tests.
 Try reducing the proof obligation before changing the program:
 
 - Reduce the entry point with `--entry-points`.
-- Restrict generated checks with `--checked-functions`.
+- Restrict function-local checks with `--checked-functions`; this also
+  suppresses user assertions in nonmatching functions, but does not filter
+  every property (as noted above for `valid-free`).
 - Lower or raise `--unroll` intentionally rather than leaving it accidental.
 - Check one property at a time with `--check`.
 - Try `--verifier=boogie` or a different `--solver` when the default back-end

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -1,12 +1,14 @@
 This document shows several usage scenarios of SMACK that require special flags.
+For the main task-oriented option guide, start with
+[Command-Line Options](command-line-options.md).
 
-## Loops and Recusive Functions
+## Loops and Recursive Functions
 First of all, please keep in mind that SMACK is a *bounded* verifier, which
-means that in the presense of loops and recursive functions, the verification
+means that in the presence of loops and recursive functions, the verification
 process unrolls them up to the bound `N` specified by the flag `--unroll <N>`.
 Conceptually, unrolling a loop means transforming a loop into a sequence (length
-`N`) of if-else statements, the inner most of which halts the program. Recursive
-functions are handled by inlining the function `N` times and the inner most
+`N`) of if-else statements, the innermost of which halts the program. Recursive
+functions are handled by inlining the function `N` times and the innermost
 recursive call halts the program. Therefore, not unrolling a loop or a recursive
 function to a sufficient bound can lead to missed bugs. In other words, when
 SMACK reports that there are no bugs in a program, it actually means that the
@@ -38,7 +40,7 @@ bitwise operations are encoded using uninterpreted functions returning
 arbitrary values.  Furthermore, precise encoding is required to handle integer
 signedness casts, which is not also enabled automatically.
 
-The following program demonstrate the problems in the presence of bitwise
+The following program demonstrates the problems in the presence of bitwise
 operations.
 
 ### Example
@@ -52,7 +54,7 @@ int main (void) {
   assert (!y);
 }
 ```
-This program should verify. However, if the we run SMACK in its default mode, it
+This program should verify. However, if we run SMACK in its default mode, it
 reports an assertion violation.
 
 ```

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -1,8 +1,13 @@
+## Usage Notes
+
 This document shows several usage scenarios of SMACK that require special flags.
 For the main task-oriented option guide, start with
 [Command-Line Options](command-line-options.md).
 
-## Loops and Recursive Functions
+<a id="loops-and-recusive-functions"></a>
+
+### Loops and Recursive Functions
+
 First of all, please keep in mind that SMACK is a *bounded* verifier, which
 means that in the presence of loops and recursive functions, the verification
 process unrolls them up to the bound `N` specified by the flag `--unroll <N>`.
@@ -10,13 +15,17 @@ Conceptually, unrolling a loop means transforming a loop into a sequence (length
 `N`) of if-else statements, the innermost of which halts the program. Recursive
 functions are handled by inlining the function `N` times and the innermost
 recursive call halts the program. Therefore, not unrolling a loop or a recursive
-function to a sufficient bound can lead to missed bugs. In other words, when
-SMACK reports that there are no bugs in a program, it actually means that the
-program is safe within the bound specified by the user.
+function to a sufficient bound can lead to missed bugs. A no-errors result means
+only that SMACK found no violation in the selected translation model within the
+specified bound; it is not, by itself, a proof of C-level safety. Modeling
+precision, such as the selected integer and floating-point encodings, is
+separate from the unrolling bound.
 
-### Example
+#### Example
+
 ```C
 #include "smack.h"
+#include <assert.h>
 
 int main (void) {
   long x = __VERIFIER_nondet_long();
@@ -32,7 +41,7 @@ default unrolling bound `1`, it reports no errors. This is because the loop has
 to be unrolled at least 4 times (i.e., after `y` gets value 3, the minimum value
 of `x`, in the 3rd iteration) for the assertion to be reachable.
 
-## Bitwise Operations and Integer Casts
+### Bitwise Operations and Integer Casts
 If the program to verify contains bitwise operations or integer casts, then the
 flag `--integer-encoding=bit-vector` may be required. The reason is that SMACK
 uses the SMT theory of integers to encode machine integers by default, where
@@ -43,9 +52,11 @@ signedness casts, which is not also enabled automatically.
 The following program demonstrates the problems in the presence of bitwise
 operations.
 
-### Example
+#### Example
+
 ```C
 #include "smack.h"
+#include <assert.h>
 
 int main (void) {
   unsigned y = __VERIFIER_nondet_unsigned_int();
@@ -70,7 +81,7 @@ Execution trace:
 SMACK found an error.
 ```
 
-Some steps in the error trace are omitted. As you can see, the concrete values
+Some steps in the error trace are omitted. As you can see, the model values
 of `y` in the error trace before and after the bitwise right shift operation do
 not follow its semantics because it is modeled as an uninterpreted function.
 
@@ -88,7 +99,7 @@ enabling this flag. However, note that enabling bit-precise reasoning often
 degrades the performance of SMACK, and causes for it to take much longer to
 perform the verification.
 
-## Floating-Point Arithmetic
+### Floating-Point Arithmetic
 Similar to machine integers, floating-point numbers and arithmetic are modeled
 using the theory of integers and uninterpreted functions, respectively.
 Therefore, if the assertions to verify depend on precise modeling of
@@ -99,7 +110,7 @@ are present.  Moreover, reasoning about floating-point numbers is often very
 slow. Please let us know if you encounter any performance issues. We can share
 some experiences that may ease the situation.
 
-## Concurrency
+### Concurrency
 Reasoning about pthreads is supported by SMACK with the flag `--pthread`. Please
 use this flag when you would like to verify a multi-threaded program with
 pthreads. One important flag for reasoning about concurrent programs is

--- a/examples/simple-project/Makefile
+++ b/examples/simple-project/Makefile
@@ -1,10 +1,11 @@
 # Set this variable to point to folder share of your SMACK installation
 INSTALL_SHARE = ../../../install/share
 
-CC = clang
-LD = llvm-link
+CC = clang-14
+LD = llvm-link-14
 INC = $(INSTALL_SHARE)/smack/include
-CFLAGS = -c -Wall -emit-llvm -O0 -g -I$(INC)
+CFLAGS = -c -Wall -emit-llvm -O0 -g -Xclang -disable-O0-optnone \
+	-fsanitize=signed-integer-overflow,shift -I$(INC)
 
 SOURCES = incr.c simple.c
 OBJS = $(subst .c,.bc,$(SOURCES))
@@ -20,4 +21,3 @@ incr.bc: incr.c incr.h
 
 clean:
 	rm -f *.bc *.bpl
-

--- a/examples/simple-project/simple.c
+++ b/examples/simple-project/simple.c
@@ -2,6 +2,7 @@
 // This file is distributed under the MIT License. See LICENSE for details.
 //
 #include "simple.h"
+#include <assert.h>
 
 void test(int a) {
   int b = a;

--- a/examples/simple/simple.c
+++ b/examples/simple/simple.c
@@ -1,5 +1,6 @@
 // examples/simple/simple.c
 #include "smack.h"
+#include <assert.h>
 #include <stdlib.h>
 
 #define TRUE 1


### PR DESCRIPTION
## Summary

Implements the documentation roadmap in #828 by consolidating and expanding
SMACK's user guidance in the repository, updated and checked against the current
command-line interface and verifier behavior.

Closes #828.

## What changed

### User documentation

- Expanded `docs/running.md` into an entry-level guide covering assertions,
  assumptions, nondeterministic inputs, result interpretation, property checks,
  multi-file programs, prelinked bitcode, and back-end selection.
- Added `docs/command-line-options.md` as a task-oriented guide to the options
  users most commonly need.
- Added `docs/build-workflows.md` for source, multi-file, saved-artifact,
  prelinked-bitcode, and Makefile workflows.
- Added `docs/advanced.md` for modeling, experimental contracts, inline Boogie,
  uninterpreted functions, initialization hooks, and trace annotations.
- Added `docs/troubleshooting.md` for common assertion, modeling, memory,
  toolchain, timeout, and generated-artifact problems.
- Updated the README table of contents and cross-links, while preserving the
  legacy misspelled `loops-and-recusive-functions` blog anchor.

### Correctness clarifications

- Documented that an explicit `--check` list replaces the default `assertions`
  property; examples select `assertions` explicitly when combining checks.
- Corrected the loop example to require `--unroll 4` and clarified that
  `--fail-on-loop-exit` reports reachable normal exits, not paths truncated by
  bound exhaustion.
- Described successful results and counterexample traces as bounded and
  model-relative, including limitations of approximate integer, bitwise, and
  floating-point encodings.
- Clarified wrapped-integer versus bit-vector use, precise `valid-free`
  semantics, and the scope of `--checked-functions` (including the shared
  `valid-free` model exception).
- Marked source-level contracts as experimental and documented the current
  return-value limitation.
- Documented all four result kinds: no errors, error, timeout, and unknown.

### Examples and LLVM workflows

- Added `<assert.h>` to the introductory C examples so their assertions are
  translated into verifier assertions rather than unresolved function calls.
- Updated manual bitcode instructions to use the LLVM major version configured
  for this checkout (`clang-14` and `llvm-link-14`).
- Documented that raw/prelinked bitcode must be compiled with
  `-fsanitize=signed-integer-overflow,shift` before SMACK can check integer
  overflow; selecting the property after compilation is too late.
- Updated `examples/simple-project/Makefile` to use the matching LLVM tools,
  preserve analyzable `-O0` IR, and include overflow instrumentation.

No production verifier implementation is changed; the non-documentation edits
are limited to the two example includes and the example Makefile.

## Testing

- `git diff --check`
- Verified relative Markdown links, internal fragments, legacy anchors, and
  balanced code fences.
- Exercised `--check` replacement and combined-property behavior.
- Confirmed the loop fixture is missed at bound 3 and found at bound 4, and that
  `--fail-on-loop-exit` reports the injected normal-exit check at bound 4.
- Confirmed raw bitcode misses signed overflow without Clang sanitizer
  instrumentation and reports it after compilation with
  `-fsanitize=signed-integer-overflow,shift`.
- Built the copied multi-file example with `clang-14`/`llvm-link-14` and verified
  the resulting bitcode with assertion and overflow checks enabled.
- Exercised the memory-safety, bit-vector, modular-contract, multi-source, and
  `--checked-functions` examples.
