### PR TITLE
Fix MergeGEP for LLVM 14

### DIFF
--- a/lib/utils/MergeGEP.cpp
+++ b/lib/utils/MergeGEP.cpp
@@ -139,12 +139,13 @@ static void simplifyGEP(GetElementPtrInst *GEP) {
     }
 
     if (!Indices.empty()){
+      Type *SourceElementType = Src->getSourceElementType();
       GetElementPtrInst *GEPNew =  (GEP->isInBounds() && Src->isInBounds()) ?
-        GetElementPtrInst::CreateInBounds(Src->getOperand(0)->getType()->getScalarType()->getPointerElementType(),
-			                  Src->getOperand(0), Indices,
+        GetElementPtrInst::CreateInBounds(SourceElementType,
+                                          Src->getOperand(0), Indices,
                                           GEP->getName(), GEP) :
-        GetElementPtrInst::Create(nullptr, Src->getOperand(0), Indices,
-                                  GEP->getName(), GEP);
+        GetElementPtrInst::Create(SourceElementType, Src->getOperand(0),
+                                  Indices, GEP->getName(), GEP);
       numMerged++;
       GEP->replaceAllUsesWith(GEPNew);
       GEP->eraseFromParent();


### PR DESCRIPTION
## Summary

Fix `MergeArrayGEP` under LLVM 14 by passing an explicit GEP source element
type when creating the merged replacement GEP.

LLVM 14 rejects `GetElementPtrInst::Create(nullptr, ...)` with:

```text
Assertion `PointeeType && "Must specify element type"' failed.
Running pass 'Merge GEPs for arrays indexing'
```

The merged GEP is rooted at the source GEP's original pointer operand, so this
uses `Src->getSourceElementType()` for both the inbounds and non-inbounds
replacement paths.

## Why

During the DD SV-COMP benchmark run after the LLVM 14 merge, llvm-14 produced
many more `unknown` results than the develop/LLVM 13 baseline. Spot checking
showed these were not Corral unknowns: they were `llvm2bpl` crashes in
`MergeArrayGEP`.

The old non-inbounds path passed `nullptr` as the GEP source element type:

```cpp
GetElementPtrInst::Create(nullptr, Src->getOperand(0), Indices, ...)
```

LLVM 14 requires the source element type explicitly, so the replacement now uses:

```cpp
Type *SourceElementType = Src->getSourceElementType();
```

## Verification

Local targeted verification with a patched LLVM 14 build:

- Rebuilt and installed the patched toolchain locally.
- Ran translation-only (`smack -t`) on all 205 SV-COMP task logs that previously
  contained the `Must specify element type` `MergeGEP` assertion.
- Result: `205 / 205` passed translation; no `MergeGEP` assertion remained.
- Also ran full SV-COMP verification on five prior crash cases:
  - `adxl34x-spi`
  - `ec_sys`
  - `bpck`
  - `ipmi_poweroff`
  - `sil164`
- All five returned `SMACK found no errors with unroll bound 1.`

Full CI still needs to confirm the change in the normal GitHub workflow.
