### PR TITLE
Handle LLVM copysign intrinsic

### DIFF
--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -1150,6 +1150,39 @@ void SmackInstGenerator::visitIntrinsicInst(llvm::IntrinsicInst &ii) {
         {&SmackOptions::FloatEnabled});
   };
 
+  static const auto copysign = conditionalModel(
+      [this](CallInst *ci) {
+        // translation:
+        //   if !$isnan.bv*($arg2) {
+        //     $res := ite($isnegative.bv*($arg1) !=
+        //                 $isnegative.bv*($arg2),
+        //                 $fneg.bv*($arg1), $arg1);
+        //   }
+        // SMT-LIB has a single NaN value, while C permits NaNs with either
+        // sign. When $arg2 is NaN, overapproximate the result sign instead
+        // of treating $isnegative.bv*($arg2) as precise.
+        auto type = rep->type(ci->getFunctionType()->getReturnType());
+        auto boolType = Naming::BOOL_TYPE;
+        auto x = rep->expr(ci->getArgOperand(0));
+        auto y = rep->expr(ci->getArgOperand(1));
+        auto result = rep->expr(ci);
+        auto isNegFn = indexedName("$isnegative", {type, boolType});
+        auto isNanFn = indexedName("$isnan", {type, boolType});
+        auto negX = Expr::fn(indexedName("$fneg", {type}), x);
+        auto signDiff = Expr::neq(Expr::fn(isNegFn, x), Expr::fn(isNegFn, y));
+        auto precise = Expr::ifThenElse(signDiff, negX, x);
+        auto isNanX = Expr::fn(isNanFn, x);
+        auto isNanY = Expr::fn(isNanFn, y);
+        auto isNanResult = Expr::fn(isNanFn, result);
+        auto nanSignResult = Expr::ifThenElse(
+            isNanX, isNanResult,
+            Expr::or_(Expr::eq(result, x), Expr::eq(result, negX)));
+        emit(Stmt::havoc(result));
+        emit(Stmt::assume(Expr::ifThenElse(isNanY, nanSignResult,
+                                           Expr::eq(result, precise))));
+      },
+      {&SmackOptions::FloatEnabled});
+
   // Expr* -> (CallInst -> Void)
   static const auto assignRoundFPFuncApp = [this](const Expr *rMode) {
     return conditionalModel(
@@ -1188,6 +1221,7 @@ void SmackInstGenerator::visitIntrinsicInst(llvm::IntrinsicInst &ii) {
           {llvm::Intrinsic::cttz, cttz},
           {llvm::Intrinsic::dbg_declare, ignore},
           {llvm::Intrinsic::dbg_label, ignore},
+          {llvm::Intrinsic::copysign, copysign},
           {llvm::Intrinsic::expect, identity},
           {llvm::Intrinsic::fabs, assignUnFPFuncApp("$abs")},
           {llvm::Intrinsic::fma, fma},
@@ -1206,11 +1240,6 @@ void SmackInstGenerator::visitIntrinsicInst(llvm::IntrinsicInst &ii) {
            assignRoundFPFuncApp(Expr::lit(RModeKind::RNA))},
           {llvm::Intrinsic::trunc,
            assignRoundFPFuncApp(Expr::lit(RModeKind::RTZ))}
-          // TODO: we cannot properly handle copysign because our fp2bv is not
-          // carefully implemented.
-          // The current version of llvm does not have these intrinsics while
-          // the latest version does
-          // we keep the code to save work in the future
           // TODO: in future versions, there may be intrinsics that round floats
           // to integers like lround
       };

--- a/test/c/mathc/copysign_nan.c
+++ b/test/c/mathc/copysign_nan.c
@@ -1,0 +1,14 @@
+#include "smack.h"
+#include <assert.h>
+#include <math.h>
+
+// @expect verified
+// @flag --integer-encoding=bit-vector
+
+int main(void) {
+  float y = __VERIFIER_nondet_float();
+  __VERIFIER_assume(__isnanf(y));
+  float val = copysignf(1.0f, y);
+  assert(val == 1.0f || val == -1.0f);
+  return 0;
+}

--- a/test/c/mathc/issue_794.c
+++ b/test/c/mathc/issue_794.c
@@ -1,0 +1,15 @@
+#include "smack.h"
+#include <math.h>
+
+// @expect verified
+// @flag --integer-encoding=bit-vector
+
+int main(void) {
+  float f = __VERIFIER_nondet_float();
+  __VERIFIER_assume(!__isnanf(f));
+  __VERIFIER_assume(0.0f < f);
+  __VERIFIER_assume(!__isinff(f));
+  float z = fmodf(f, 2.0f);
+  __VERIFIER_assert(z <= 2.0f);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add `--float` translation for `llvm.copysign.*` intrinsics
- model ordinary `copysign(x, y)` by comparing operand sign predicates and applying `fp.neg` when needed
- account for #477 by conservatively overapproximating `copysign(x, NaN)`, where SMT-LIB cannot distinguish signed NaN payload/sign variants
- add focused regressions for direct NaN-sign behavior and the #794 `fmodf` path

Fixes #801.
Addresses the #794 translation failure.
Related to #477.

## Notes
The #794 regression is intentionally a float version of the issue-comment program. The exact comment used a nondeterministic `double` as the input to `fmodf`; that conversion can produce a `float` infinity before `fmodf`, making the assertion invalid for reasons unrelated to the missing `copysign.f32` translation.

## Testing
- `cmake --build build --target llvm2bpl`
- `git diff --cached --check`
- `/tmp/smack-install-820/bin/smack test/c/mathc/copysign.c --float --integer-encoding=bit-vector --verifier=boogie --time-limit 60`
- `/tmp/smack-install-820/bin/smack test/c/mathc/copysignf.c --float --integer-encoding=bit-vector --verifier=boogie --time-limit 60`
- `/tmp/smack-install-820/bin/smack test/c/mathc/issue_794.c --float --integer-encoding=bit-vector --verifier=boogie --time-limit 60`
- `/tmp/smack-install-820/bin/smack test/c/mathc/copysign_nan.c --float --integer-encoding=bit-vector --verifier=boogie --time-limit 60`

Note: `cmake --install build --prefix /tmp/smack-install-820` copied the usable install tree but failed at the end on `build/install_manifest.txt` due to the existing local ownership/permission issue.
