### PR TITLE
Handle constrained FP intrinsics conservatively

### DIFF
--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -1218,8 +1218,16 @@ void SmackInstGenerator::visitIntrinsicInst(llvm::IntrinsicInst &ii) {
   auto it = stmtMap.find(ii.getIntrinsicID());
   if (it != stmtMap.end())
     it->second(&ii);
-  else if (ii.getIntrinsicID() ==
-           llvm::Intrinsic::experimental_noalias_scope_decl) {
+  else if (ii.getCalledFunction()->getName().startswith(
+               "llvm.experimental.constrained.")) {
+    SmackWarnings::warnApproximate(ii.getCalledFunction()->getName().str(),
+                                   currBlock, &ii);
+    if (!ii.getType()->isVoidTy())
+      emit(Stmt::havoc(rep->expr(&ii)));
+    else
+      emit(Stmt::skip());
+  } else if (ii.getIntrinsicID() ==
+             llvm::Intrinsic::experimental_noalias_scope_decl) {
     // Ignore this function as we cannot handle arguments of metadata type.
   } else {
     SmackWarnings::warnApproximate(ii.getCalledFunction()->getName().str(),

--- a/test/c/float/constrained_intrinsic.c
+++ b/test/c/float/constrained_intrinsic.c
@@ -1,0 +1,13 @@
+#include "smack.h"
+
+// @expect verified
+
+int main(void) {
+#pragma STDC FENV_ACCESS ON
+  volatile float x = 2.0f;
+  volatile float y = 1.0f;
+  float z = x / y;
+  (void)z;
+  __VERIFIER_assert(1);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- handle llvm.experimental.constrained.* before the generic intrinsic fallback
- warn that constrained FP intrinsics are approximated and havoc their result instead of emitting calls with metadata operands
- add a float regression that forces a constrained fdiv intrinsic

Fixes #795.

## Testing
- cmake --build build --target llvm2bpl
- git diff --check
- /tmp/smack-install-795/bin/smack test/c/float/constrained_intrinsic.c --float --verifier=boogie --time-limit 60
- /tmp/smack-install-795/bin/smack /tmp/constrained.c --float --verifier=boogie --time-limit 60

The full issue-style sample now warns for constrained fdiv/fcmp and no longer crashes; because fcmp is approximated, that sample can report an error.