### PR TITLE
Fix README CI badge endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![main branch ci status](https://github.com/smackers/smack/workflows/SMACK%20CI/badge.svg?branch=main)](https://github.com/smackers/smack/actions)
-[![develop branch ci status](https://github.com/smackers/smack/workflows/SMACK%20CI/badge.svg?branch=develop)](https://github.com/smackers/smack/actions)
+[![main branch ci status](https://github.com/smackers/smack/actions/workflows/smack-ci.yaml/badge.svg?branch=main)](https://github.com/smackers/smack/actions)
+[![develop branch ci status](https://github.com/smackers/smack/actions/workflows/smack-ci.yaml/badge.svg?branch=develop)](https://github.com/smackers/smack/actions)
 
 <img src="docs/smack-logo.png" width=400 alt="SMACK Logo" align="right">
 
@@ -62,4 +62,3 @@ benchmarking of SMACK.
 1. [Projects](docs/projects.md)
 1. [Publications](docs/publications.md)
 1. [People](docs/people.md)
-


### PR DESCRIPTION
## Summary
- update README CI badges to use the workflow-file badge endpoint
- keep both `main` and `develop` branch badges pointing at the SMACK CI workflow

## Testing
- `git diff --check`
- verified both replacement badge SVG endpoints return `SMACK CI - passing`
