### PR TITLE
Include assert.h in rise4fun examples

### DIFF
--- a/examples/rise4fun/rise_simple.c
+++ b/examples/rise4fun/rise_simple.c
@@ -1,4 +1,5 @@
 #include "smack.h"
+#include <assert.h>
 
 int main(void) {
   int x, y, z;

--- a/examples/rise4fun/rise_simple_buggy.c
+++ b/examples/rise4fun/rise_simple_buggy.c
@@ -1,4 +1,5 @@
 #include "smack.h"
+#include <assert.h>
 
 int main(void) {
   int x, y, z;


### PR DESCRIPTION
Fixes #769.

The rise4fun examples use the C `assert` macro but only included `smack.h`. Without `<assert.h>`, clang treats `assert` as an implicit external function, so SMACK translates an ordinary `assert(...)` call instead of the intended `__VERIFIER_assert` check.

This adds the missing include to both rise4fun examples.

Verification:

- `/tmp/smack-install-820/bin/smack -t examples/rise4fun/rise_simple.c -ll /tmp/rise_simple_fixed.ll -bpl /tmp/rise_simple_fixed.bpl`
- `/tmp/smack-install-820/bin/smack -t examples/rise4fun/rise_simple_buggy.c -ll /tmp/rise_simple_buggy_fixed.ll -bpl /tmp/rise_simple_buggy_fixed.bpl`
- Confirmed generated LLVM calls `@__VERIFIER_assert` instead of an undeclared `@assert`.
- `git diff --check`
