### PR TITLE
Make NormalizeLoops a loop pass

### DIFF
--- a/include/smack/NormalizeLoops.h
+++ b/include/smack/NormalizeLoops.h
@@ -4,19 +4,19 @@
 #ifndef NORMALIZELOOPS_H
 #define NORMALIZELOOPS_H
 
+#include "llvm/Analysis/LoopPass.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
 #include <map>
 
 namespace smack {
 
-class NormalizeLoops : public llvm::ModulePass {
+class NormalizeLoops : public llvm::LoopPass {
 public:
   static char ID; // Pass identification, replacement for typeid
-  NormalizeLoops() : llvm::ModulePass(ID) {}
+  NormalizeLoops() : llvm::LoopPass(ID) {}
   virtual llvm::StringRef getPassName() const override;
-  virtual bool runOnModule(llvm::Module &m) override;
+  virtual bool runOnLoop(llvm::Loop *L, llvm::LPPassManager &LPM) override;
   virtual void getAnalysisUsage(llvm::AnalysisUsage &) const override;
 };
 } // namespace smack

--- a/lib/smack/NormalizeLoops.cpp
+++ b/lib/smack/NormalizeLoops.cpp
@@ -11,6 +11,7 @@
 #include "smack/NormalizeLoops.h"
 #include "smack/Naming.h"
 #include "llvm/Analysis/LoopInfo.h"
+#include "llvm/Analysis/LoopPass.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/IRBuilder.h"
@@ -25,7 +26,6 @@ namespace smack {
 
 using namespace llvm;
 
-// Register LoopInfo
 void NormalizeLoops::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.addRequired<LoopInfoWrapperPass>();
 }
@@ -69,7 +69,8 @@ std::vector<unsigned> getSuccessorIndices(Instruction *ti,
  * \param blockMap is updated to map between \param BB and the newly created
  * forwarding block.
  */
-void splitBlock(BasicBlock *BB, BasicBlock *headerBlock,
+void splitBlock(Loop *loop, LoopInfo &loopInfo, BasicBlock *BB,
+                BasicBlock *headerBlock,
                 std::map<BasicBlock *, BasicBlock *> &blockMap) {
   Instruction *ti = BB->getTerminator();
 
@@ -81,6 +82,7 @@ void splitBlock(BasicBlock *BB, BasicBlock *headerBlock,
   // index uses the same forwarding block.
   if (succIndices.size()) {
     BasicBlock *forwarder = makeForwardingBlock(headerBlock);
+    loop->addBasicBlockToLoop(forwarder, loopInfo);
     blockMap[BB] = forwarder;
     for (auto succIndex : succIndices) {
       ti->setSuccessor(succIndex, forwarder);
@@ -106,7 +108,7 @@ void processPhis(std::vector<PHINode *> &phis,
   }
 }
 
-void processLoop(Loop *loop) {
+bool processLoop(Loop *loop, LoopInfo &loopInfo) {
   std::vector<PHINode *> phis;
   std::set<BasicBlock *> phiIncBlocks;
   std::set<BasicBlock *> loopBlocks(loop->block_begin(), loop->block_end());
@@ -127,31 +129,18 @@ void processLoop(Loop *loop) {
     if (loopBlocks.count(BB) == 0) {
       continue;
     }
-    splitBlock(BB, headerBlock, blockMap);
+    splitBlock(loop, loopInfo, BB, headerBlock, blockMap);
   }
 
   // Fix up Phi nodes
   processPhis(phis, blockMap);
 
-  // Handle subloops
-  for (Loop *subloop : loop->getSubLoops()) {
-    processLoop(subloop);
-  }
+  return !blockMap.empty();
 }
 
-bool NormalizeLoops::runOnModule(Module &m) {
-  for (auto F = m.begin(), FEnd = m.end(); F != FEnd; ++F) {
-    if (F->isIntrinsic() || F->empty()) {
-      continue;
-    }
-    LoopInfo &loopInfo = getAnalysis<LoopInfoWrapperPass>(*F).getLoopInfo();
-    for (LoopInfo::iterator LI = loopInfo.begin(), LIEnd = loopInfo.end();
-         LI != LIEnd; ++LI) {
-      processLoop(*LI);
-    }
-  }
-
-  return true;
+bool NormalizeLoops::runOnLoop(Loop *L, LPPassManager &LPM) {
+  LoopInfo &loopInfo = getAnalysis<LoopInfoWrapperPass>().getLoopInfo();
+  return processLoop(L, loopInfo);
 }
 
 // Pass ID variable


### PR DESCRIPTION
Fixes #605.

`NormalizeLoops` was a `ModulePass`, but its transformation is local to a single loop. This refactors it to a legacy `LoopPass` and lets LLVM's loop pass manager visit each loop directly.

Details:

- `NormalizeLoops` now derives from `llvm::LoopPass`.
- `runOnModule` is replaced by `runOnLoop`.
- The manual recursive subloop walk is removed; the loop pass manager handles loop traversal.
- Inserted forwarding blocks are added to `LoopInfo` with `Loop::addBasicBlockToLoop`, keeping loop analysis coherent while the pass is running.

Verification:

- `cmake --build build --target llvm2bpl`
- `git diff --check`
- Ran rebuilt `build/llvm2bpl` on a driver-linked loop input from `test/c/basic/loop.c`.
- Ran rebuilt `build/llvm2bpl` on a targeted LLVM IR input with a conditional backedge to the loop header; confirmed final IR rewrites the backedge through `%forwarder` and updates the header PHI incoming block to `%forwarder`.
