### PR TITLE
Fix vector bitwise and comparison translation

### DIFF
--- a/lib/smack/SmackInstGenerator.cpp
+++ b/lib/smack/SmackInstGenerator.cpp
@@ -338,10 +338,15 @@ void SmackInstGenerator::visitUnreachableInst(llvm::UnreachableInst &ii) {
 
 void SmackInstGenerator::visitBinaryOperator(llvm::BinaryOperator &I) {
   processInstruction(I);
-  if (rep->isBitwiseOp(&I) && I.getType()->getIntegerBitWidth() > 1)
-    SmackWarnings::warnOverApproximate(
-        std::string("bitwise operation ") + I.getOpcodeName(),
-        {&SmackOptions::BitPrecise}, currBlock, &I);
+  if (rep->isBitwiseOp(&I)) {
+    auto T = I.getType();
+    if (auto VT = dyn_cast<FixedVectorType>(T))
+      T = VT->getElementType();
+    if (T->isIntegerTy() && T->getIntegerBitWidth() > 1)
+      SmackWarnings::warnOverApproximate(
+          std::string("bitwise operation ") + I.getOpcodeName(),
+          {&SmackOptions::BitPrecise}, currBlock, &I);
+  }
   if (rep->isFpArithOp(&I))
     SmackWarnings::warnOverApproximate(
         std::string("floating-point operation ") + I.getOpcodeName(),

--- a/lib/smack/VectorOperations.cpp
+++ b/lib/smack/VectorOperations.cpp
@@ -74,7 +74,22 @@ FuncDecl *VectorOperations::cast(unsigned OpCode, Type *SrcTy, Type *DstTy) {
     Body = Expr::fn(constructor(DstVecTy), Expr::id("v"));
   else if (SrcVecTy && SrcVecTy->getNumElements() == 1 && !DstVecTy)
     Body = Expr::fn(selector(SrcVecTy, 0), Expr::id("v"));
-  else
+  else if ((OpCode == Instruction::Trunc || OpCode == Instruction::ZExt ||
+            OpCode == Instruction::SExt) &&
+           SrcVecTy && DstVecTy &&
+           CastInst::castIsValid((Instruction::CastOps)OpCode,
+                                 SrcVecTy->getElementType(),
+                                 DstVecTy->getElementType()) &&
+           SrcVecTy->getNumElements() == DstVecTy->getNumElements()) {
+    auto FnBase =
+        rep->opName(Naming::INSTRUCTION_TABLE.at(OpCode),
+                    {SrcVecTy->getElementType(), DstVecTy->getElementType()});
+    std::list<const Expr *> Args;
+    for (unsigned i = 0; i < SrcVecTy->getNumElements(); i++)
+      Args.push_back(
+          Expr::fn(FnBase, Expr::fn(selector(SrcVecTy, i), Expr::id("v"))));
+    Body = Expr::fn(constructor(DstVecTy), Args);
+  } else
     Body = nullptr;
 
   return Decl::function(FnName, {{"v", rep->type(SrcTy)}}, rep->type(DstTy),
@@ -109,33 +124,35 @@ FuncDecl *VectorOperations::binary(unsigned OpCode, FixedVectorType *T) {
 FuncDecl *VectorOperations::cmp(CmpInst::Predicate P, FixedVectorType *T) {
   auto FnName = rep->opName(Naming::CMPINST_TABLE.at(P), {T});
   auto FnBase = rep->opName(Naming::CMPINST_TABLE.at(P), {T->getElementType()});
+  auto RT = FixedVectorType::get(IntegerType::get(T->getContext(), 1),
+                                 T->getNumElements());
   std::list<const Expr *> Args;
   for (unsigned i = 0; i < T->getNumElements(); i++) {
     Args.push_back(
         Expr::fn(FnBase, {Expr::fn(selector(T, i), Expr::id("v1")),
                           Expr::fn(selector(T, i), Expr::id("v2"))}));
   }
-  return Decl::function(
-      FnName, {{"v1", rep->type(T)}, {"v2", rep->type(T)}},
-      rep->type(FixedVectorType::get(IntegerType::get(T->getContext(), 1),
-                                     T->getNumElements())),
-      Expr::fn(constructor(T), Args));
+  return Decl::function(FnName, {{"v1", rep->type(T)}, {"v2", rep->type(T)}},
+                        rep->type(RT), Expr::fn(constructor(RT), Args));
 }
 
 FuncDecl *VectorOperations::cast(CastInst *I) {
   SDEBUG(errs() << "simd-cast: " << *I << "\n");
   auto F = cast(I->getOpcode(), I->getSrcTy(), I->getDestTy());
-  auto G = cast(I->getOpcode(), I->getDestTy(), I->getSrcTy());
-  auto A = inverseAxiom(I->getOpcode(), I->getSrcTy(), I->getDestTy());
-  auto B = inverseAxiom(I->getOpcode(), I->getDestTy(), I->getSrcTy());
   if (isa<FixedVectorType>(I->getSrcTy()))
     type(I->getSrcTy());
   if (isa<FixedVectorType>(I->getDestTy()))
     type(I->getDestTy());
   rep->addAuxiliaryDeclaration(F);
-  rep->addAuxiliaryDeclaration(G);
-  rep->addAuxiliaryDeclaration(A);
-  rep->addAuxiliaryDeclaration(B);
+
+  if (I->getOpcode() == Instruction::BitCast) {
+    auto G = cast(I->getOpcode(), I->getDestTy(), I->getSrcTy());
+    auto A = inverseAxiom(I->getOpcode(), I->getSrcTy(), I->getDestTy());
+    auto B = inverseAxiom(I->getOpcode(), I->getDestTy(), I->getSrcTy());
+    rep->addAuxiliaryDeclaration(G);
+    rep->addAuxiliaryDeclaration(A);
+    rep->addAuxiliaryDeclaration(B);
+  }
   return F;
 }
 

--- a/test/c/simd/vector_bitwise.c
+++ b/test/c/simd/vector_bitwise.c
@@ -1,0 +1,11 @@
+// @expect verified
+// @checkbpl grep "function \$and.vec.2xi32.*returns (vec.2xi32) { mk.vec.2xi32"
+
+typedef int v2i __attribute__((vector_size(8)));
+
+int main(void) {
+  v2i x = {1, 2};
+  v2i y = {3, 1};
+  v2i z = x & y;
+  return z[0];
+}

--- a/test/c/simd/vector_compare.c
+++ b/test/c/simd/vector_compare.c
@@ -1,0 +1,17 @@
+#include "smack.h"
+#include <assert.h>
+
+// @expect verified
+// @checkbpl grep "function \$eq.vec.2xi32.*returns (vec.2xi1) { mk.vec.2xi1"
+// @checkbpl grep "function \$sext.vec.2xi1.vec.2xi32"
+
+typedef int v2i __attribute__((vector_size(8)));
+
+int main(void) {
+  v2i x = {1, 2};
+  v2i y = {1, 3};
+  v2i z = x == y;
+  assert(z[0] != 0);
+  assert(z[1] == 0);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- avoid crashing on vector bitwise operations when deciding whether to warn about approximate bitwise translation
- construct vector comparison results with the result vector type (vec.Nxi1) instead of the operand vector type
- add SIMD regressions for vector bitwise and vector comparison translation

Fixes #735.
Fixes #736.

## Testing
- cmake --build /tmp/smack-736/build --target llvm2bpl
- cmake --build /tmp/smack-736/build --target install
- generated BPL for test/c/simd/vector_bitwise.c and checked $and.vec.2xi32 uses mk.vec.2xi32
- generated BPL for test/c/simd/vector_compare.c and checked $eq.vec.2xi32 returns vec.2xi1 using mk.vec.2xi1

Full local Boogie verification was not run because boogie is not installed in this environment.
