### PR TITLE
Move rounding mode initialization to fenv model

### DIFF
--- a/lib/smack/SmackRep.cpp
+++ b/lib/smack/SmackRep.cpp
@@ -1246,10 +1246,6 @@ Decl *SmackRep::getInitFuncs() {
   Block *b = Block::block();
   for (auto name : initFuncs)
     b->addStmt(Stmt::call(name));
-  if (SmackOptions::FloatEnabled) {
-    b->addStmt(
-        Stmt::assign(Expr::id(Naming::RMODE_VAR), Expr::lit(RModeKind::RNE)));
-  }
   b->addStmt(Stmt::return_());
   proc->getBlocks().push_back(b);
   return proc;

--- a/share/smack/lib/fenv.c
+++ b/share/smack/lib/fenv.c
@@ -4,6 +4,8 @@
 #include <fenv.h>
 #include <smack.h>
 
+__SMACK_INIT(initializeRoundingMode) { __SMACK_code("$rmode := RNE;"); }
+
 int fegetround(void) {
   const int CONST_FE_TONEAREST = FE_TONEAREST;
   const int CONST_FE_DOWNWARD = FE_DOWNWARD;

--- a/test/c/float/rmode_init.c
+++ b/test/c/float/rmode_init.c
@@ -1,0 +1,12 @@
+#include "smack.h"
+#include <assert.h>
+#include <fenv.h>
+
+// @expect verified
+// @checkbpl grep "call __SMACK_init_func_initializeRoundingMode();"
+// @checkbpl grep "\\$rmode := RNE;"
+
+int main(void) {
+  assert(fegetround() == FE_TONEAREST);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- move default floating-point rounding mode initialization from the translator into the fenv runtime model
- add a __SMACK_INIT hook in share/smack/lib/fenv.c that initializes $rmode to RNE
- add a float regression checking that $initialize calls the fenv init and that the runtime emits the $rmode assignment

Fixes #621.

## Testing
- cmake --build /tmp/smack-621/build --target llvm2bpl
- cmake --build /tmp/smack-621/build --target install
- generated BPL for test/c/float/rmode_init.c with --float and checked:
  - call __SMACK_init_func_initializeRoundingMode();
  - $rmode := RNE;

Full local Boogie verification was not run because boogie is not installed in this environment.
