### PR TITLE
Avoid redundant split aggregate memory checks

### DIFF
--- a/include/smack/MemorySafetyChecker.h
+++ b/include/smack/MemorySafetyChecker.h
@@ -21,6 +21,7 @@ private:
   void insertMemoryLeakCheck(llvm::Instruction *I);
   void insertMemoryAccessCheck(llvm::Value *addr, llvm::Value *size,
                                llvm::Instruction *I);
+  bool visitSplitAggregateAccess(llvm::Value *addr, llvm::Instruction *I);
 
 public:
   static char ID; // Pass identification, replacement for typeid

--- a/include/smack/SplitAggregateValue.h
+++ b/include/smack/SplitAggregateValue.h
@@ -14,6 +14,11 @@
 
 namespace smack {
 
+namespace SplitAggregateValueMetadata {
+extern const char MemoryAccess[];
+extern const char WholeMemoryAccess[];
+} // namespace SplitAggregateValueMetadata
+
 class SplitAggregateValue : public llvm::FunctionPass {
 public:
   typedef std::vector<std::pair<llvm::Value *, unsigned>> IndexT;
@@ -25,9 +30,11 @@ public:
 private:
   llvm::Value *splitAggregateLoad(llvm::Type *T, llvm::Value *P,
                                   std::vector<InfoT> &info,
-                                  llvm::IRBuilder<> &irb);
+                                  llvm::IRBuilder<> &irb,
+                                  bool preserveWholeAccessCheck);
   void splitAggregateStore(llvm::Value *P, llvm::Value *V,
-                           std::vector<InfoT> &info, llvm::IRBuilder<> &irb);
+                           std::vector<InfoT> &info, llvm::IRBuilder<> &irb,
+                           bool preserveWholeAccessCheck);
   void splitConstantReturn(llvm::ReturnInst *ri, std::vector<InfoT> &info);
   void splitConstantArg(llvm::CallInst *ci, unsigned i,
                         std::vector<InfoT> &info);

--- a/lib/smack/MemorySafetyChecker.cpp
+++ b/lib/smack/MemorySafetyChecker.cpp
@@ -5,11 +5,13 @@
 #include "smack/Debug.h"
 #include "smack/Naming.h"
 #include "smack/SmackOptions.h"
+#include "smack/SplitAggregateValue.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/Operator.h"
 #include "llvm/IR/ValueSymbolTable.h"
 
 namespace smack {
@@ -71,15 +73,18 @@ void MemorySafetyChecker::visitReturnInst(llvm::ReturnInst &I) {
 }
 
 namespace {
+Value *accessSizeAsPointer(Module &M, Type *T) {
+  return ConstantExpr::getIntToPtr(
+      ConstantInt::get(Type::getInt64Ty(M.getContext()),
+                       M.getDataLayout().getTypeStoreSize(T)),
+      PointerType::getUnqual(Type::getInt8Ty(M.getContext())));
+}
+
 Value *accessSizeAsPointer(Module &M, Value *V) {
   auto T = dyn_cast<PointerType>(V->getType());
   assert(T && "expected pointer type");
 
-  return ConstantExpr::getIntToPtr(
-      ConstantInt::get(
-          Type::getInt64Ty(M.getContext()),
-          M.getDataLayout().getTypeStoreSize(T->getPointerElementType())),
-      PointerType::getUnqual(Type::getInt8Ty(M.getContext())));
+  return accessSizeAsPointer(M, T->getPointerElementType());
 }
 
 Value *accessSizeAsPointer(LoadInst &I) {
@@ -93,11 +98,44 @@ Value *accessSizeAsPointer(StoreInst &I) {
 }
 } // namespace
 
+bool MemorySafetyChecker::visitSplitAggregateAccess(Value *addr,
+                                                    Instruction *I) {
+  if (!I->getMetadata(SplitAggregateValueMetadata::MemoryAccess))
+    return false;
+
+  // SplitAggregateValue lowers one aggregate access into multiple scalar
+  // accesses. Check the original aggregate access once, then skip the pieces.
+  if (I->getMetadata(SplitAggregateValueMetadata::WholeMemoryAccess)) {
+    auto &M = *I->getParent()->getParent()->getParent();
+    Value *base = addr;
+    Type *T = nullptr;
+
+    if (auto *GEP = dyn_cast<GEPOperator>(addr)) {
+      base = GEP->getPointerOperand();
+      T = GEP->getSourceElementType();
+    } else {
+      auto *PT = dyn_cast<PointerType>(addr->getType());
+      assert(PT && "expected pointer type");
+      T = PT->getPointerElementType();
+    }
+
+    insertMemoryAccessCheck(base, accessSizeAsPointer(M, T), I);
+  }
+
+  return true;
+}
+
 void MemorySafetyChecker::visitLoadInst(LoadInst &I) {
+  if (visitSplitAggregateAccess(I.getPointerOperand(), &I))
+    return;
+
   insertMemoryAccessCheck(I.getPointerOperand(), accessSizeAsPointer(I), &I);
 }
 
 void MemorySafetyChecker::visitStoreInst(StoreInst &I) {
+  if (visitSplitAggregateAccess(I.getPointerOperand(), &I))
+    return;
+
   insertMemoryAccessCheck(I.getPointerOperand(), accessSizeAsPointer(I), &I);
 }
 

--- a/lib/smack/SplitAggregateValue.cpp
+++ b/lib/smack/SplitAggregateValue.cpp
@@ -8,6 +8,22 @@ namespace smack {
 
 using namespace llvm;
 
+namespace SplitAggregateValueMetadata {
+const char MemoryAccess[] = "split.aggregate.memory_access";
+const char WholeMemoryAccess[] = "split.aggregate.whole_memory_access";
+} // namespace SplitAggregateValueMetadata
+
+namespace {
+void markSplitAggregateAccess(Instruction *I, bool checkWholeAccess) {
+  auto &C = I->getContext();
+  auto *Marker =
+      MDNode::get(C, ConstantAsMetadata::get(ConstantInt::getTrue(C)));
+  I->setMetadata(SplitAggregateValueMetadata::MemoryAccess, Marker);
+  if (checkWholeAccess)
+    I->setMetadata(SplitAggregateValueMetadata::WholeMemoryAccess, Marker);
+}
+} // namespace
+
 std::vector<Value *> getFirsts(SplitAggregateValue::IndexT lst) {
   std::vector<Value *> ret;
   for (auto &p : lst)
@@ -34,7 +50,7 @@ bool SplitAggregateValue::runOnFunction(Function &F) {
           visitAggregateValue(nullptr, li->getType(), idx, info, C);
           IRBuilder<> irb(li);
           li->replaceAllUsesWith(splitAggregateLoad(
-              li->getType(), li->getPointerOperand(), info, irb));
+              li->getType(), li->getPointerOperand(), info, irb, true));
           toRemove.push_back(li);
         }
       } else if (StoreInst *si = dyn_cast<StoreInst>(&I)) {
@@ -44,7 +60,7 @@ bool SplitAggregateValue::runOnFunction(Function &F) {
                               info, C);
           IRBuilder<> irb(si);
           splitAggregateStore(si->getPointerOperand(), si->getValueOperand(),
-                              info, irb);
+                              info, irb, true);
           toRemove.push_back(si);
         }
       } else if (ReturnInst *ri = dyn_cast<ReturnInst>(&I)) {
@@ -84,34 +100,41 @@ bool SplitAggregateValue::isConstantAggregate(Value *V) {
 
 Value *SplitAggregateValue::splitAggregateLoad(Type *T, Value *P,
                                                std::vector<InfoT> &info,
-                                               IRBuilder<> &irb) {
+                                               IRBuilder<> &irb,
+                                               bool preserveWholeAccessCheck) {
   Value *V = UndefValue::get(T);
+  bool checkWholeAccess = preserveWholeAccessCheck;
   for (auto &e : info) {
     IndexT idxs = std::get<0>(e);
     Value *p = irb.CreateGEP(T, P, ArrayRef<Value *>(getFirsts(idxs)));
-    V = irb.CreateInsertValue(
-        V,
-        irb.CreateLoad(p->getType()->getScalarType()->getPointerElementType(),
-                       p),
-        ArrayRef<unsigned>(getSeconds(idxs)));
+    auto *load = irb.CreateLoad(
+        p->getType()->getScalarType()->getPointerElementType(), p);
+    markSplitAggregateAccess(load, checkWholeAccess);
+    checkWholeAccess = false;
+    V = irb.CreateInsertValue(V, load, ArrayRef<unsigned>(getSeconds(idxs)));
   }
   return V;
 }
 
 void SplitAggregateValue::splitAggregateStore(Value *P, Value *V,
                                               std::vector<InfoT> &info,
-                                              IRBuilder<> &irb) {
+                                              IRBuilder<> &irb,
+                                              bool preserveWholeAccessCheck) {
+  bool checkWholeAccess = preserveWholeAccessCheck;
   for (auto &e : info) {
     IndexT idxs = std::get<0>(e);
     Constant *c = std::get<1>(e);
     std::vector<Value *> vidxs = getFirsts(idxs);
     Type *T = P->getType()->getScalarType()->getPointerElementType();
+    Value *p = irb.CreateGEP(T, P, ArrayRef<Value *>(vidxs));
+    StoreInst *store;
     if (c)
-      irb.CreateStore(c, irb.CreateGEP(T, P, ArrayRef<Value *>(vidxs)));
+      store = irb.CreateStore(c, p);
     else
-      irb.CreateStore(
-          irb.CreateExtractValue(V, ArrayRef<unsigned>(getSeconds(idxs))),
-          irb.CreateGEP(T, P, ArrayRef<Value *>(vidxs)));
+      store = irb.CreateStore(
+          irb.CreateExtractValue(V, ArrayRef<unsigned>(getSeconds(idxs))), p);
+    markSplitAggregateAccess(store, checkWholeAccess);
+    checkWholeAccess = false;
   }
 }
 
@@ -119,8 +142,8 @@ Value *SplitAggregateValue::createInsertedValue(IRBuilder<> &irb, Type *T,
                                                 std::vector<InfoT> &info,
                                                 Value *V) {
   Value *box = irb.CreateAlloca(T);
-  splitAggregateStore(box, V, info, irb);
-  return splitAggregateLoad(T, box, info, irb);
+  splitAggregateStore(box, V, info, irb, false);
+  return splitAggregateLoad(T, box, info, irb, false);
 }
 
 void SplitAggregateValue::splitConstantReturn(ReturnInst *ri,

--- a/test/c/memory-safety/split-aggregate/config.yml
+++ b/test/c/memory-safety/split-aggregate/config.yml
@@ -1,0 +1,6 @@
+verifiers: [boogie]
+checkbpl:
+  - >-
+    awk '/^procedure .*fun/ { in_fun=1 } in_fun && /call __SMACK_check_memory_safety/ { n++ } in_fun && /^}/ { in_fun=0 } END { exit n == 3 ? 0 : 1 }'
+  - >-
+    awk '/^procedure .*fun/ { in_fun=1 } in_fun && index($0, "i2p.i64.ref(16)") { n++ } in_fun && /^}/ { in_fun=0 } END { exit n == 1 ? 0 : 1 }'

--- a/test/c/memory-safety/split-aggregate/split_aggregate_value.c
+++ b/test/c/memory-safety/split-aggregate/split_aggregate_value.c
@@ -1,0 +1,21 @@
+#include <stddef.h>
+
+// @expect verified
+// @flag --clang-options="-O2 -Xclang -disable-llvm-passes"
+
+typedef struct {
+  char *p;
+  size_t n;
+} pair_t;
+
+pair_t fun(void) {
+  pair_t r;
+  r.p = 0;
+  r.n = 0;
+  return r;
+}
+
+int main(void) {
+  pair_t x = fun();
+  return x.n != 0;
+}


### PR DESCRIPTION
Fixes #710.

### Problem

`SplitAggregateValue` lowers one aggregate load/store into several scalar
GEP+load/store operations. Since it runs before `MemorySafetyChecker`, those
synthetic scalar operations were each instrumented independently. For example,
a 16-byte aggregate access could become two 8-byte memory-safety checks even
though the source operation was one aggregate access.

### Approach

This keeps the original memory-safety obligation but avoids checking every
scalarized piece:

- `SplitAggregateValue` tags the scalar loads/stores it creates with internal
  metadata.
- The first scalar access produced for a real aggregate load/store is marked as
  the representative whole-aggregate access.
- `MemorySafetyChecker` turns that representative access into one check on the
  original aggregate base pointer and aggregate type size.
- The remaining scalarized accesses are skipped.
- Split loads/stores used only for internal constant-aggregate materialization
  are skipped without adding a source-level memory-safety obligation.

This is intentionally not a blanket suppression of all split aggregate memory
operations. Aggregate accesses through arbitrary pointers still get checked;
they are just checked once at the original aggregate size.

### Regression

Adds a C memory-safety regression for aggregate return lowering. The test uses
`-O2 -Xclang -disable-llvm-passes`: optimized frontend lowering produces the
aggregate return shape, while disabling later LLVM passes prevents that shape
from being lowered away before SMACK sees it.

The regression checks that `fun` emits the two real scalar stores into the local
struct plus exactly one 16-byte check for the split aggregate load used to
return the value. Before this change, the same case emitted four 8-byte checks.

### Validation

- `ninja -C build -j2`
- `git diff --check`
- `python3 test/regtest.py --folder c/memory-safety/split-aggregate --languages c --threads 1 --log INFO --all-examples`
