### PR TITLE
Merge release 2.10.0 back into develop

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -5,7 +5,7 @@
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = smack
-PROJECT_NUMBER         = 2.9.0
+PROJECT_NUMBER         = 2.10.0
 PROJECT_BRIEF          = "A bounded software verifier."
 PROJECT_LOGO           =
 OUTPUT_DIRECTORY       = docs

--- a/share/smack/reach.py
+++ b/share/smack/reach.py
@@ -11,7 +11,7 @@ import json
 from smackgen import *
 from smackverify import *
 
-VERSION = '2.9.0'
+VERSION = '2.10.0'
 
 
 def reachParser():

--- a/share/smack/top.py
+++ b/share/smack/top.py
@@ -17,7 +17,7 @@ from .replay import replay_error_trace
 from .frontend import link_bc_files, frontends, languages, extra_libs
 from .errtrace import error_trace, json_output_str
 
-VERSION = '2.9.0'
+VERSION = '2.10.0'
 
 
 class VResult(Flag):


### PR DESCRIPTION
Merge the 2.10.0 release branch back into `develop`, following the existing SMACK release process.

This carries the release version bump from 2.9.0 to 2.10.0 back to `develop`.

Changed files:

- `Doxyfile`
- `share/smack/reach.py`
- `share/smack/top.py`