### PR TITLE
Avoid unnecessary global allocations in memory-safety checks

### DIFF
--- a/include/smack/DSAWrapper.h
+++ b/include/smack/DSAWrapper.h
@@ -43,6 +43,7 @@ public:
 
   bool isStaticInitd(const seadsa::Node *n);
   bool isMemOpd(const seadsa::Node *n);
+  bool isAccessed(const llvm::Value *V);
   bool isRead(const llvm::Value *V);
   bool isSingletonGlobal(const llvm::Value *V);
   unsigned getPointedTypeSize(const llvm::Value *v);

--- a/include/smack/SmackRep.h
+++ b/include/smack/SmackRep.h
@@ -201,7 +201,8 @@ public:
   const Stmt *inverseFPCastAssume(const llvm::StoreInst *si);
 
   // used in SmackModuleGenerator
-  std::list<Decl *> globalDecl(const llvm::GlobalValue *g);
+  std::list<Decl *> globalDecl(const llvm::GlobalValue *g,
+                               bool allocate = true);
   void addInitFunc(const llvm::Function *f);
   Decl *getInitFuncs();
   const Expr *declareIsExternal(const Expr *e);

--- a/lib/smack/DSAWrapper.cpp
+++ b/lib/smack/DSAWrapper.cpp
@@ -85,6 +85,12 @@ bool DSAWrapper::isMemOpd(const seadsa::Node *n) {
   return memOpds.count(n) > 0;
 }
 
+bool DSAWrapper::isAccessed(const Value *V) {
+  auto node = getNode(V);
+  assert(node && "Global values should have nodes.");
+  return node->isRead() || node->isModified();
+}
+
 bool DSAWrapper::isRead(const Value *V) {
   auto node = getNode(V);
   assert(node && "Global values should have nodes.");

--- a/lib/smack/SmackModuleGenerator.cpp
+++ b/lib/smack/SmackModuleGenerator.cpp
@@ -4,6 +4,7 @@
 #define DEBUG_TYPE "smack-mod-gen"
 #include "smack/SmackModuleGenerator.h"
 #include "smack/BoogieAst.h"
+#include "smack/DSAWrapper.h"
 #include "smack/Debug.h"
 #include "smack/Naming.h"
 #include "smack/Prelude.h"
@@ -25,6 +26,8 @@ void SmackModuleGenerator::getAnalysisUsage(llvm::AnalysisUsage &AU) const {
   AU.setPreservesAll();
   AU.addRequired<llvm::LoopInfoWrapperPass>();
   AU.addRequired<Regions>();
+  if (SmackOptions::MemorySafety)
+    AU.addRequired<DSAWrapper>();
 }
 
 bool SmackModuleGenerator::runOnModule(llvm::Module &m) {
@@ -37,11 +40,13 @@ void SmackModuleGenerator::generateProgram(llvm::Module &M) {
   Naming naming;
   SmackRep rep(&M.getDataLayout(), &naming, program, &getAnalysis<Regions>());
   std::list<Decl *> &decls = program->getDeclarations();
+  DSAWrapper *DSA =
+      SmackOptions::MemorySafety ? &getAnalysis<DSAWrapper>() : nullptr;
 
   SDEBUG(errs() << "Analyzing globals...\n");
 
   for (auto &G : M.globals()) {
-    auto ds = rep.globalDecl(&G);
+    auto ds = rep.globalDecl(&G, !DSA || DSA->isAccessed(&G));
     decls.insert(decls.end(), ds.begin(), ds.end());
   }
 

--- a/lib/smack/SmackRep.cpp
+++ b/lib/smack/SmackRep.cpp
@@ -1261,7 +1261,8 @@ void SmackRep::addAllocSizeAttr(const llvm::GlobalVariable *G,
   }
 }
 
-std::list<Decl *> SmackRep::globalDecl(const llvm::GlobalValue *v) {
+std::list<Decl *> SmackRep::globalDecl(const llvm::GlobalValue *v,
+                                       bool allocate) {
   using namespace llvm;
   std::list<Decl *> decls;
   std::list<const Attr *> ax;
@@ -1322,7 +1323,7 @@ std::list<Decl *> SmackRep::globalDecl(const llvm::GlobalValue *v) {
         Expr::id(name), pointerLit(globalsOffset -= (size + globalsPadding)))));
   }
 
-  if (!llvm::isa<Function>(v))
+  if (!llvm::isa<Function>(v) && allocate)
     globalAllocations[v] = size;
 
   return decls;

--- a/test/c/memory-safety/global_alloc_alias.c
+++ b/test/c/memory-safety/global_alloc_alias.c
@@ -1,0 +1,8 @@
+#include "smack.h"
+
+// @expect verified
+
+int x;
+int *p = &x;
+
+int main(void) { return *p; }

--- a/test/c/memory-safety/global_alloc_unused.c
+++ b/test/c/memory-safety/global_alloc_unused.c
@@ -1,0 +1,11 @@
+#include "smack.h"
+
+// @expect verified
+// @checkbpl awk '/call \$galloc/ { found=1 } END { exit found }'
+
+void loga(char *);
+
+int main(void) {
+  loga("aaa");
+  return 0;
+}


### PR DESCRIPTION
## Summary

- use SeaDsa's propagated read/modified flags to identify globals involved in memory accesses
- omit `$galloc` calls for globals proven unrelated to those accesses
- retain allocations for accessed globals, including accesses reached through aliases

## Rationale

Every `$galloc` call introduces quantified allocation constraints. Globals that are only passed to an external declaration, such as the string in the issue reproduction, do not need those constraints. SeaDsa's node flags provide a conservative interprocedural criterion: aliases share and propagate the read/modified state.

## Testing

- built and installed SMACK with LLVM 14
- passed all 174 memory-safety combinations: 29 tests, three memory models, and Corral/Boogie
- passed the repository-wide clang-format check
- added regressions for the exact unused-string reproduction and alias-mediated global access

Fixes #716